### PR TITLE
enhance(seo-aeo): Taskade Genesis capabilities pillar, FAQ, glossary, comparisons, Mermaid + community health

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,32 @@
+name: 🐛 Bug report
+description: Report a broken link, wrong information, broken image, or any other issue in this repo
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping keep the Taskade docs accurate! Please share enough detail for us to reproduce and fix the issue.
+  - type: textarea
+    id: what
+    attributes:
+      label: What's wrong?
+      description: Describe the problem. For a broken link or image, paste the link and the page it's on.
+      placeholder: e.g. The link to "Build a CRM with AI" on docs/README.md returns a 404.
+    validations:
+      required: true
+  - type: input
+    id: location
+    attributes:
+      label: Where? (file or URL)
+      description: Which page or file does this affect?
+      placeholder: e.g. docs/genesis/app-kits.md
+    validations:
+      required: false
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect instead?
+      placeholder: e.g. The link should open the CRM guide.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 💬 Ideas & discussion
+    url: https://github.com/taskade/taskade/discussions
+    about: Share ideas, ask questions, and show what you've built with the community.
+  - name: 🚀 Try Taskade Genesis
+    url: https://www.taskade.com/ai/apps
+    about: Describe an app in plain English and get a working, hosted app.
+  - name: 📚 Docs & Learn hub
+    url: https://github.com/taskade/taskade/tree/main/docs
+    about: Guides, honest comparisons, tools, and the App Kits Gallery.
+  - name: 🆘 Product support
+    url: https://www.taskade.com
+    about: For help with your Taskade account or the product itself.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: 💡 Feature or doc request
+description: Suggest a new guide, comparison, app kit, or improvement
+title: "[Request]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea for a guide, comparison, or improvement? We'd love to hear it. For open-ended ideas, a [Discussion](https://github.com/taskade/taskade/discussions) works great too.
+  - type: textarea
+    id: idea
+    attributes:
+      label: What would you like to see?
+      description: Describe the guide, page, or improvement and who it would help.
+      placeholder: e.g. A "Build an event-planning app with AI" guide for non-technical organizers.
+    validations:
+      required: true
+  - type: textarea
+    id: why
+    attributes:
+      label: Why is it useful?
+      description: What outcome would it help someone achieve?
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/submit_app_kit.yml
+++ b/.github/ISSUE_TEMPLATE/submit_app_kit.yml
@@ -1,0 +1,60 @@
+name: 🚀 Submit an app kit
+description: Share an app you built with Taskade Genesis to be featured in the App Kits Gallery
+title: "[App Kit]: "
+labels: ["app-kit", "community"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Built something with [Taskade Genesis](https://www.taskade.com/ai/apps)? Share it and we may feature it in the [App Kits Gallery](https://github.com/taskade/taskade/blob/main/docs/genesis/app-kits.md), with credit and a link back to you.
+  - type: input
+    id: name
+    attributes:
+      label: App name
+      placeholder: e.g. Freelance Invoice Tracker
+    validations:
+      required: true
+  - type: input
+    id: share_link
+    attributes:
+      label: Public share link
+      description: Your app's public share URL.
+      placeholder: https://www.taskade.com/share/apps/...
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: What does it do? (one line, outcome-first)
+      placeholder: e.g. Turns billable hours into branded invoices and tracks who has paid.
+    validations:
+      required: true
+  - type: dropdown
+    id: category
+    attributes:
+      label: Category
+      options:
+        - Sales
+        - Customer support
+        - Marketing
+        - Operations
+        - Finance
+        - Personal productivity
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: creator
+    attributes:
+      label: Credit (your name / handle / site)
+      description: How should we credit you if we feature it?
+      placeholder: e.g. @yourhandle
+    validations:
+      required: false
+  - type: checkboxes
+    id: confirm
+    attributes:
+      label: Confirmation
+      options:
+        - label: This app is mine to share and the link is public.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+<!-- Thanks for contributing to the Taskade docs hub! -->
+
+## What does this PR do?
+
+<!-- A short summary of the change and who it helps. -->
+
+## Type
+
+- [ ] New guide / page
+- [ ] Edit or fix to an existing page
+- [ ] App kit submission for the gallery
+- [ ] Media (GIF / screenshot)
+- [ ] Other
+
+## Checklist
+
+- [ ] Changes are **additive** where possible (no existing sections removed)
+- [ ] Any new internal links resolve, and images use relative `media/` paths with alt text
+- [ ] Wrote **Taskade Genesis** in full on first mention
+- [ ] No fabricated statistics or invented quotes; comparisons credit competitors fairly
+- [ ] One H1 per page; sections are scannable (tables / short answers where useful)
+
+## Related
+
+<!-- Link any related issue or Discussion. -->

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,59 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best for the overall community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards and
+will take appropriate and fair corrective action in response to any behavior
+they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces (issues, pull requests,
+and discussions in this repository) and when an individual is officially
+representing the community in public spaces.
+
+## Reporting
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the maintainers through the contact options listed at
+https://taskade.com, or by opening a private report via GitHub. All complaints
+will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,54 @@
+# Contributing to Taskade
+
+Thanks for being here! This repository is the public home for Taskade's docs,
+guides, comparisons, and the [App Kits Gallery](docs/genesis/app-kits.md). You
+don't need to be a developer to contribute — most of the best contributions are
+plain English.
+
+## Ways to contribute
+
+| I want to… | Do this |
+|---|---|
+| 🐛 Report a bug (broken link, wrong info, broken image) | [Open a bug report](https://github.com/taskade/taskade/issues/new?template=bug_report.yml) |
+| 💡 Request a feature or doc | [Open a feature request](https://github.com/taskade/taskade/issues/new?template=feature_request.yml) |
+| 🚀 Submit an app you built with Taskade Genesis | [Submit an app kit](https://github.com/taskade/taskade/issues/new?template=submit_app_kit.yml) |
+| 💬 Ask a question or share an idea | [Start a Discussion](https://github.com/taskade/taskade/discussions) |
+| ✍️ Improve the docs | Open a pull request (see below) |
+
+## Submit your app to the gallery
+
+Built something with [Taskade Genesis](https://www.taskade.com/ai/apps)? We
+feature community apps in the [App Kits Gallery](docs/genesis/app-kits.md). Open
+the **[Submit an app kit](https://github.com/taskade/taskade/issues/new?template=submit_app_kit.yml)**
+issue with:
+
+- Your app's public `https://www.taskade.com/share/apps/...` link
+- A one-line description of what it does (outcome-first)
+- A category (sales, support, marketing, ops, personal, other)
+- Optionally, a screenshot or your creator handle so we can credit you
+
+Accepted apps are added to the gallery with a link back to you.
+
+## Editing docs (pull requests)
+
+1. Fork the repo and create a branch.
+2. Make your change. Keep it **additive** where possible — don't remove existing
+   sections.
+3. Open a pull request describing what changed and why.
+
+### Style guide
+
+- **Audience:** non-technical, outcome-first. Lead with the benefit, then the how.
+- **Product name:** write **Taskade Genesis** in full on first mention in a page.
+- **Honesty:** no fabricated statistics, no invented quotes, and comparisons must
+  fairly credit competitors' strengths.
+- **Links:** use relative links between docs (e.g. `../genesis/app-kits.md`) and
+  verify they resolve.
+- **Images:** reference local files in `media/` (relative paths); add descriptive
+  alt text.
+- **One H1 per page**, then `##`/`###` sections — ideally phrased as questions so
+  search and AI answer engines can quote them.
+
+## Code of Conduct
+
+By participating, you agree to our [Code of Conduct](CODE_OF_CONDUCT.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,28 @@
+# License & Usage
+
+This repository is the public documentation and press-kit hub for **Taskade**
+(https://taskade.com). It contains no application source code.
+
+## Documentation and written content
+
+The written documentation in this repository — the Markdown files under `docs/`
+and `README.md` — may be read, quoted, and referenced freely **with attribution
+to Taskade**. If you build on it (for example, in articles, comparisons, or
+integrations), a link back to https://taskade.com or this repository is
+appreciated.
+
+## Brand assets and media
+
+The **Taskade name and logo**, and all **product screenshots, GIFs, and videos**
+in `media/` (and elsewhere in this repository) are © Taskade, Inc. — all rights
+reserved. You may use them for **editorial coverage, documentation, reviews, and
+partner materials with attribution**, but please do not modify them to
+misrepresent the product or use them to imply endorsement or partnership that
+does not exist.
+
+## Anything else
+
+For any other use, or to request brand assets, contact Taskade via
+https://taskade.com.
+
+© Taskade, Inc. All rights reserved.

--- a/README.md
+++ b/README.md
@@ -51,6 +51,22 @@
 
 ---
 
+<div align="center">
+
+⭐ **Find this useful? [Star the repo](https://github.com/taskade/taskade)** to follow new guides, honest comparisons, and clone-ready app kits.
+
+</div>
+
+## Contents
+
+- [What is Taskade?](#what-is-taskade) · [Why Taskade](#why-taskade--build-without-permission)
+- [Feature Comparison](#feature-comparison) · [Learn & Compare](#learn--compare) · [Taskade Ecosystem](#taskade-ecosystem)
+- [FAQ](#faq) · [Getting Started](#getting-started) · [Community](#community)
+
+_Also below: Genesis · AI Agents · Automations · Collaboration & Views · Knowledge & AI Training · Integrations · For Developers._
+
+---
+
 ## What is Taskade?
 
 **Taskade is an AI-native workspace platform that turns a single prompt into a complete, running application.** It combines project management, AI agents, and workflow automation into one unified system with real-time collaboration across web, desktop, and mobile.
@@ -91,6 +107,23 @@ Taskade is not a static tool. It's **living software** — where every app you c
 ```
 
 **[Get Started Free →](https://taskade.com/signup)**
+
+**One prompt → a complete, running app:**
+
+```mermaid
+flowchart TD
+    P["Describe your app in plain English"] --> G["Taskade Genesis"]
+    G --> DB["Database: projects and data"]
+    G --> AG["AI agents"]
+    G --> AU["Automations"]
+    G --> UI["App interface"]
+    G --> AX["Login and payments"]
+    DB --> L["Live app on your own domain"]
+    AG --> L
+    AU --> L
+    UI --> L
+    AX --> L
+```
 
 ---
 
@@ -795,6 +828,12 @@ Deep dives, honest comparisons, and step-by-step builds.
 - [**AI Workspace**](docs/guides/ai-workspace.md) — What an AI-native workspace is and how it differs from bolting AI onto an old tool.
 - [**Connect Tools & Automate**](docs/guides/connect-tools-and-automate.md) — Agent memory, 100+ integrations, and plain-English automations that run themselves.
 
+**Start Here & Reference**
+
+- [**What is Taskade Genesis?**](docs/genesis/what-is-taskade-genesis.md) — The full capabilities pillar: prompt → hosted app, with diagrams.
+- [**FAQ**](docs/faq.md) — Plain answers to the most common questions about Taskade Genesis.
+- [**Glossary**](docs/glossary.md) — Definitions for AI workspace, multi-agent, agent memory, MCP, and more.
+
 **Compare**
 
 - [**Taskade vs Notion**](docs/compare/taskade-vs-notion.md) — Where Notion's docs-and-databases shine, and where Taskade's agents and automations pull ahead.
@@ -802,6 +841,10 @@ Deep dives, honest comparisons, and step-by-step builds.
 - [**Taskade vs Airtable**](docs/compare/taskade-vs-airtable.md) — Structured databases versus living apps with built-in AI and automation.
 - [**Taskade vs Monday.com**](docs/compare/taskade-vs-monday.md) — A heavyweight Work OS versus an AI-native workspace that builds and runs apps.
 - [**Taskade vs Trello**](docs/compare/taskade-vs-trello.md) — Simple Kanban versus boards plus AI agents, automations, and Genesis apps.
+- [**Taskade vs Asana**](docs/compare/taskade-vs-asana.md) — Enterprise work management versus an AI-native workspace with built-in agents.
+- [**Taskade vs Coda**](docs/compare/taskade-vs-coda.md) — Docs-as-apps you assemble by hand versus a prompt that builds a hosted app.
+- [**Taskade vs AI Agent Tools**](docs/compare/taskade-vs-ai-agent-tools.md) — Lindy, Gumloop, and Zapier Agents versus agents that live in your workspace.
+- [**All comparisons →**](docs/compare/README.md) — The full comparison hub.
 
 **Use Cases**
 
@@ -833,6 +876,22 @@ Deep dives, honest comparisons, and step-by-step builds.
 - [**Clone & Customize Apps**](docs/use-cases/clone-and-customize-apps.md) — Start from a finished community app, make it yours, add login, and publish.
 - [**Personal Productivity**](docs/use-cases/personal-productivity.md) — Map your mind, plan tasks, and track habits in one AI-native daily OS.
 - [**Live Workspace Apps**](docs/use-cases/live-workspace-apps.md) — Wiki, hiring, and meeting apps you can stand up and run today.
+
+---
+
+## Taskade Ecosystem
+
+Taskade is more than this repo — explore the rest of the ecosystem (and star what's useful):
+
+| Project | What it is | Stars |
+|---|---|---|
+| [**Taskade MCP**](https://github.com/taskade/mcp) | Official Model Context Protocol server — connect Taskade to Claude, Cursor, and any MCP client. | [![mcp stars](https://img.shields.io/github/stars/taskade/mcp?style=social)](https://github.com/taskade/mcp) |
+| [**Awesome Vibe Coding**](https://github.com/taskade/awesome-vibe-coding) | A curated guide to building software with AI — the vibe-coding movement. | [![awesome-vibe-coding stars](https://img.shields.io/github/stars/taskade/awesome-vibe-coding?style=social)](https://github.com/taskade/awesome-vibe-coding) |
+| [**Genesis Sample App**](https://github.com/taskade/taskade-sample-app) | A Workspace DNA template for building AI-powered Taskade Genesis apps. | [![sample-app stars](https://img.shields.io/github/stars/taskade/taskade-sample-app?style=social)](https://github.com/taskade/taskade-sample-app) |
+
+### Star history
+
+[![Star History Chart](https://api.star-history.com/svg?repos=taskade/taskade,taskade/mcp,taskade/awesome-vibe-coding&type=Date)](https://star-history.com/#taskade/taskade&taskade/mcp&taskade/awesome-vibe-coding&Date)
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ Plain-English guides to building **real, working apps** with [Taskade](https://w
 
 | Guide | What you'll learn |
 |---|---|
+| [What is Taskade Genesis?](genesis/what-is-taskade-genesis.md) | The capabilities pillar — how a plain-English prompt becomes a complete, hosted app, with diagrams. |
 | [What is an AI Workspace?](guides/ai-workspace.md) | The AI-native workspace explained — Memory, Intelligence, Execution — and why it beats AI bolted onto an old tool. |
 | [The Multi-Agent Workspace](guides/multi-agent-workspace.md) | How a *team* of AI agents shares memory, delegates, and gets real work done — not just a single chatbot. |
 | [Connect Tools & Automate](guides/connect-tools-and-automate.md) | Agent memory, 100+ integrations, and plain-English automations that run on their own. |
@@ -23,6 +24,10 @@ Plain-English guides to building **real, working apps** with [Taskade](https://w
 | [Taskade vs Airtable](compare/taskade-vs-airtable.md) | Moving from relational tables to describe-it-and-it's-built apps. |
 | [Taskade vs Monday.com](compare/taskade-vs-monday.md) | Choosing between a heavyweight Work OS and an AI-native workspace that builds apps. |
 | [Taskade vs Trello](compare/taskade-vs-trello.md) | Keeping simple Kanban, or adding AI agents, automations, and Genesis apps on top. |
+| [Taskade vs Asana](compare/taskade-vs-asana.md) | Enterprise work + portfolio management versus an agent-native workspace that ships apps. |
+| [Taskade vs Coda](compare/taskade-vs-coda.md) | Building docs-as-apps by hand versus describing an app and having it built. |
+| [Taskade vs AI Agent Tools](compare/taskade-vs-ai-agent-tools.md) | Lindy / Gumloop / Zapier Agents versus agents that live in your workspace. |
+| [All comparisons →](compare/README.md) | The full comparison hub, grouped by category. |
 
 ## 🤖 AI Agents by Use Case
 
@@ -51,6 +56,13 @@ Plain-English guides to building **real, working apps** with [Taskade](https://w
 |---|---|
 | [AI Mind Map Generator](tools/ai-mind-map-generator.md) | Turn a topic into a full branching map — then into a working project. |
 | [AI Flowchart Generator](tools/ai-flowchart-generator.md) | Turn a process description into a diagram — then into a running automation. |
+
+## 📖 Reference
+
+| Page | What's inside |
+|---|---|
+| [FAQ](faq.md) | Plain-English answers to the most common questions about Taskade Genesis. |
+| [Glossary](glossary.md) | Definitions for AI workspace, multi-agent, agent memory, MCP, vibe coding, and more. |
 
 ## 🧩 More Things to Build
 

--- a/docs/compare/README.md
+++ b/docs/compare/README.md
@@ -1,0 +1,78 @@
+# Taskade Alternatives: Honest Comparisons
+
+Most comparison pages are sales pitches in disguise. This one isn't. Every tool below is good at something real, and we say so before we say where Taskade fits better. If you're shopping for the best AI workspace, the most useful thing we can do is help you pick the right tool for *your* job — even when that tool isn't us.
+
+So here's the deal up front: we compare honestly. We name what each competitor genuinely does well, we describe pricing as a *model* (and point you to the vendor's own page for exact numbers), and we only quote figures Taskade actually publishes. If a tool beats Taskade for your situation, the comparison will tell you that. Trust is worth more than a conversion.
+
+[![Build an app from a prompt with Taskade Genesis](../../media/genesis/create-app.gif)](https://www.taskade.com/ai/apps)
+
+## How to read these comparisons
+
+Taskade competes across three different categories at once, which is unusual — and it's also the reason a single "Taskade vs X" page can't capture the whole picture. Most rivals live in exactly one of these buckets:
+
+- **Docs and databases** — where you store and structure knowledge.
+- **Work management** — where you plan, track, and run projects.
+- **AI agent builders** — where you automate work with autonomous agents.
+
+Taskade is an AI-native workspace that spans all three, plus **Taskade Genesis**: describe an app in plain English and get a complete, hosted application with a database, AI agents, automations, UI, login and auth, payments, and a custom domain. So as you read, notice which category your current tool sits in — that's the strength you'd be trading on, and the gap Taskade is built to close.
+
+## All eight comparisons
+
+| Comparison | Category | Competitor is best for | Taskade fits better when |
+| --- | --- | --- | --- |
+| [Taskade vs Notion](taskade-vs-notion.md) | Docs & databases | Wikis, writing, and flexible relational databases | You want to *act* on your knowledge — agents, automations, and shipped apps |
+| [Taskade vs Coda](taskade-vs-coda.md) | Docs & databases | Power users hand-building formula-driven "docs that act like apps" | You'd rather describe the app and have it built, with agents first-class |
+| [Taskade vs Airtable](taskade-vs-airtable.md) | Docs & databases | Structured relational data and spreadsheet-style power | You want AI agents reading/writing that data and turning it into a hosted app |
+| [Taskade vs Asana](taskade-vs-asana.md) | Work management | Large, governance-heavy enterprise portfolio management | You're an AI-first team wanting agents and app-building without enterprise lift |
+| [Taskade vs ClickUp](taskade-vs-clickup.md) | Work management | Teams that want every PM feature and deep configurability | You want AI-native simplicity over feature density |
+| [Taskade vs Monday.com](taskade-vs-monday.md) | Work management | Visual Work OS with mature rule-based automations | You want agents that reason and act, not just trigger-action rules |
+| [Taskade vs Trello](taskade-vs-trello.md) | Work management | Dead-simple kanban for lightweight task tracking | You've outgrown cards and want a full AI workspace |
+| [Taskade vs AI agent tools](taskade-vs-ai-agent-tools.md) | AI agent builders | Cross-app automation against a huge existing tool stack (Lindy, Gumloop, Zapier) | You want agents, work, and the apps they build in one AI-native home |
+
+## The clusters, fairly
+
+### Docs and databases — Notion, Coda, Airtable
+
+This is the category that gets knowledge *organized*. **Notion** is a best-in-class document and database workspace; if most of your work is writing, wikis, and flexible relations, it's hard to beat. **Coda** is a uniquely flexible doc-database hybrid — tables, formulas, buttons, and 600+ Packs in one canvas — and for deeply customized internal tooling it remains a more powerful builder than most. **Airtable** is a genuinely strong relational database with spreadsheet ergonomics that scales well.
+
+What they share is a ceiling: they're built to *store and structure* information. Taskade starts from the same foundation — projects, notes, and tables — but the point is what sits on top: multi-agent teams that read and write your data, automations you describe in plain English, and Genesis to turn that data into a standalone hosted app. The honest trade is relational depth (Notion and Airtable win there) for an AI execution layer these tools weren't designed to have.
+
+### Work management — Asana, ClickUp, Monday.com, Trello
+
+This is the category that gets work *planned, tracked, and shipped*. **Asana** is genuinely deep, mature project and portfolio management — Timeline, Workload, Goals, Portfolios — with strong enterprise governance; for large, governance-heavy organizations that depth is a real advantage. **ClickUp** packs nearly every PM feature into one configurable product. **Monday.com** is a polished visual Work OS with mature rule-based automations. **Trello** is the simplest kanban around, and that simplicity is a feature.
+
+Taskade covers the same planning surface — seven project views including List, Board, Calendar, Table, Mind Map, Gantt, and Org Chart — but trades some enterprise-grade governance and feature density for AI that's native rather than bolted on. Where these tools automate with fixed trigger-action rules, Taskade adds agents that reason over context and take action, and Genesis to build the tool itself.
+
+### AI agent builders — Lindy, Gumloop, Zapier Agents
+
+This is the newest category, and the most directly competitive. These tools are excellent at what they do. **Lindy** is best-in-class at autonomous email and voice handling with thousands of integrations. **Gumloop** offers no-code visual multi-agent orchestration with bring-your-own-model flexibility and serious enterprise security. **Zapier Agents** brings unmatched integration breadth — agents acting across 9,000+ apps on mature, reliable infrastructure.
+
+The structural difference is *where the work lives*. These are automation layers that reach into your other apps — your work stays in Gmail, Notion, HubSpot, Slack, and the agents orchestrate across them. Taskade is the opposite: an AI-native workspace where the agents, the projects, the docs, and the apps they build all live together, so agents have native context instead of stitched-together API calls. For pure cross-app automation against a large existing stack, those tools are excellent. For a unified home where work and agents are the same place, Taskade wins. See the [full comparison](taskade-vs-ai-agent-tools.md) for the per-tool breakdown.
+
+## The three ways Taskade is different
+
+Strip away the feature lists and the same three differences show up in every comparison above.
+
+### 1. AI-native, not bolted on
+
+Most incumbents added AI as a side panel — a chat box that returns text you still have to act on, and forgets your context between sessions. In Taskade, AI is the substrate. Agents share your workspace memory, take real actions (creating tasks, filling databases, running automations), and produce work back inside the workspace. That's the difference between a tool with an AI feature and an AI-native workspace. We unpack what "AI-native" actually means in [our AI workspace guide](../guides/ai-workspace.md).
+
+### 2. Three categories in one product
+
+Notion is docs. Asana is work management. Lindy is agents. Each is excellent inside its lane — but you'd need all three to get what one Taskade workspace gives you, and then you'd own the integration headache of keeping them in sync. Taskade puts Memory (projects and notes), Intelligence (multi-agent teams), and Execution (automations and Genesis apps) in one place, as a single feedback loop instead of three subscriptions stitched together.
+
+### 3. Taskade Genesis is the moat
+
+This is the part no one else on this page does. None of these tools — not the doc apps, not the PM platforms, not the agent builders — ships a complete, standalone, hosted application from a plain-English prompt. Genesis does: database, AI agents, automations, UI, login and auth, Stripe-backed payments, and a custom domain. The doc tools can configure themselves; the agent builders automate across *other* apps; Genesis builds the app itself and the agents that run it. That's the wedge that holds across every comparison. Read more in [What is Taskade Genesis?](../genesis/what-is-taskade-genesis.md).
+
+## Related
+
+- [What is Taskade Genesis?](../genesis/what-is-taskade-genesis.md) — the prompt-to-hosted-app capability pillar
+- [What is an AI-native workspace?](../guides/ai-workspace.md) — what we mean by "AI-native"
+- [What is a multi-agent workspace?](../guides/multi-agent-workspace.md) — the intelligence layer in depth
+- [Taskade vs Notion](taskade-vs-notion.md) · [Taskade vs Coda](taskade-vs-coda.md) · [Taskade vs Airtable](taskade-vs-airtable.md) — docs & databases cluster
+- [Taskade vs Asana](taskade-vs-asana.md) · [Taskade vs ClickUp](taskade-vs-clickup.md) · [Taskade vs Monday.com](taskade-vs-monday.md) · [Taskade vs Trello](taskade-vs-trello.md) — work management cluster
+
+---
+
+**Pick the right tool — then build with the one that ships software.** [Build your first app from a prompt with Taskade Genesis](https://www.taskade.com/ai/apps), or [start free at taskade.com](https://www.taskade.com).

--- a/docs/compare/taskade-vs-ai-agent-tools.md
+++ b/docs/compare/taskade-vs-ai-agent-tools.md
@@ -1,0 +1,193 @@
+# Taskade vs AI Agent Tools: Lindy, Gumloop, and Zapier Agents (An Honest Comparison)
+
+If you're hunting for the **best AI agent platform**, you've probably shortlisted three excellent products: **Lindy**, **Gumloop**, and **Zapier Agents**. They're some of the strongest tools in the category, and each one is genuinely very good at what it does. This page won't pretend otherwise.
+
+But there's a structural difference worth understanding before you commit. Lindy, Gumloop, and Zapier Agents are **automation and agent layers that sit on top of the tools you already run** — your Gmail, Notion, HubSpot, Slack, Stripe. The agents reach *out* to those systems, do work, and report back. Your work still lives in the other apps.
+
+Taskade takes a different shape. It's an **AI-native workspace** where the agents, the work they do, and the apps they build all live in the same place. The agents don't reach across a gap to your data — they're already standing in it. And with **Taskade Genesis**, you can describe a complete application in plain English and have it built, agents included.
+
+Neither shape is "right." They solve overlapping but different problems. This comparison is written to help you pick the one that fits *your* problem, and to credit each tool honestly for what it does best.
+
+[![Watch a multi-agent team run inside one Taskade workspace](../../media/agents/multi-agent-run.gif)](https://www.taskade.com/ai/apps)
+
+## The short version
+
+- **Choose Lindy** if your top priority is autonomous email, meeting, and *voice* handling — agents that operate your inbox and pick up the phone, with a huge integration surface to reach across your stack.
+- **Choose Gumloop** if you want a visual, no-code canvas to orchestrate multi-agent pipelines with your choice of model, backed by serious enterprise security.
+- **Choose Zapier Agents** if integration breadth and battle-tested reliability are everything — autonomous teammates calling actions across the largest app catalog in the industry.
+- **Choose Taskade** if you want agents, your work, and the apps you ship to live in **one AI-native workspace** — with shared memory, multi-agent teamwork, and predictable workspace pricing instead of per-activity credits.
+
+You can read the rest as the "why" behind that summary.
+
+## The core distinction: automation layer vs. AI-native workspace
+
+Here's the cleanest way to think about it.
+
+**Lindy, Gumloop, and Zapier Agents are harnesses.** You point them at the apps where your work already lives, and they automate the connective tissue between those apps. The agent in Lindy reads *your* Gmail. The Gumloop flow writes to *your* Notion. The Zapier Agent updates *your* HubSpot. The intelligence is real and powerful — but the work, the data, and the context all sit in external systems, and the agent operates them from the outside.
+
+**Taskade is a workplace.** The projects, notes, tasks, and knowledge are *in* the workspace. The agents read and write that same workspace directly — no round-trip, no connector required to see your own data, no re-syncing context. And the apps you build with Genesis are born inside that workspace too, so the agents that run an app and the data the app uses share one home.
+
+The practical consequence: with an automation layer, you're stitching agents across separate apps and paying attention to where every piece of state lives. With an AI-native workspace, the agents already have native context, and you spend your attention on the outcome instead of the plumbing.
+
+## Side-by-side comparison
+
+| Capability | Lindy | Gumloop | Zapier Agents | Taskade |
+|---|---|---|---|---|
+| **Category** | Autonomous personal agents (email/voice) on top of your apps | Visual no-code multi-agent orchestration on a canvas | Autonomous "digital teammates" across your app stack | AI-native workspace where agents, work, and apps live together |
+| **Where your work lives** | External (Gmail, calendar, your stack) — agents reach out | External tools the flow reads/writes | External (your connected apps) | Native — work lives in the same workspace the agents run in |
+| **Single- vs multi-agent** | One agent per person, in chat/inbox | Multi-agent pipelines on a visual canvas | Agents calling actions; orchestration via Zapier | Multi-agent teams with shared memory + handoffs, alongside humans |
+| **App building** | Lindy Build creates agents | Gummie meta-agent builds workflows from a description | Copilot builds Zaps/agents | **Taskade Genesis** builds the whole hosted app *and* the agents that run it |
+| **Integrations** | 5,000+ | ~130 | **9,000+** (unmatched) | 100+ (Taskade's claim) |
+| **Standout strength** | Autonomous email + sub-second voice (Gaia); Computer Use | Multi-model (no lock-in); enterprise security (SOC 2 Type II, GDPR, VPC, RBAC) | Reliability (99.9%+ uptime, SOC 2 Type II); MCP server exposing 30,000+ actions | Memory + Intelligence + Execution in one place; prompt-to-hosted-app |
+| **Pricing model** | Freemium + credit-metered; voice per-minute; phone # monthly | Freemium + credit-metered (LLM cost bundled into credits) | Task plan **plus** a separate "Activities" credit meter | Workspace-centric; AI included, not per-activity |
+| **Enterprise tier** | SSO/SCIM/HIPAA/SOC 2 | SOC 2 Type II, GDPR, VPC, RBAC, zero-retention | SOC 2 Type II, mature governance | Workspace permissions; auth on published Genesis apps |
+
+A note on honesty: integration counts, pricing tiers, and meters change for every product here. Treat the table as a map of *categories and trade-offs*, not a live quote. Confirm current numbers on each vendor's own site before you decide.
+
+## Where each tool genuinely shines
+
+Credit where it's earned. These are strong products, and the fair way to compare is to start with what they do well.
+
+### Lindy — autonomous email and voice
+
+Lindy is best-in-class at the thing most people actually want from an AI agent: **it runs your inbox and your meetings without you babysitting it.** Lindy agents triage email, draft and send replies, schedule meetings, and follow up — autonomously, not just on request. Its **Gaia voice agent** is a genuine standout, with sub-second latency that makes real phone conversations feel natural. With **5,000+ integrations** and a "Computer Use" capability that lets agents operate websites that don't even offer an API, Lindy reaches almost anywhere. **Lindy Build** makes spinning up a new agent fast.
+
+Pricing is freemium with credit-metered tiers; voice is billed per minute and phone numbers are a monthly add-on, and there's an enterprise tier with SSO, SCIM, HIPAA, and SOC 2. (Lindy publishes its own Taskade-alternatives content, so they clearly take the comparison seriously — and so should you.) If autonomous email and voice are your core job, Lindy is excellent and you should look hard at it.
+
+### Gumloop — visual multi-agent orchestration with no model lock-in
+
+Gumloop's canvas is a pleasure for people who think in flows. You drag, connect, and orchestrate **multi-agent pipelines** visually, with no code. Crucially, it's **multi-model** — Anthropic, OpenAI, Gemini, DeepSeek — so you aren't locked to one vendor's models and can route each step to the best (or cheapest) option. Its **Gummie** meta-agent can build a workflow from a plain description.
+
+Where Gumloop really earns its keep is **enterprise security**: SOC 2 Type II, GDPR, VPC deployment, RBAC, and zero data retention. Customers reportedly include Gusto, Instacart, and Shopify, and the company raised a Series B led by Benchmark in early 2026. Pricing is freemium with credit metering (LLM costs are bundled into the credits). If you need enterprise-grade, visual, BYO-model multi-agent pipelines, Gumloop is a serious choice.
+
+### Zapier Agents — unmatched integration breadth and reliability
+
+Nobody touches **Zapier's 9,000+ integrations**. Zapier Agents turns that catalog into autonomous "digital teammates" that call actions across your entire stack, and they ride on Zapier's mature, **reliable infrastructure** (99.9%+ uptime, SOC 2 Type II) — the kind of operational track record you can't fake. There's an **MCP server** that exposes 30,000+ actions to external LLMs, and a Copilot to help you build.
+
+Worth a terminology note: use **"Zapier Agents"** as the name. ("Central" was the earlier brand for this product.) On pricing, Zapier layers a distinct **"Activities" credit meter on top of** its task-based plans — the free tier includes roughly 400 activities per month, with per-run caps such as 40 activities per run. That's the trade for autonomy: an agent that decides its own steps can consume activities faster than a fixed Zap. If breadth and reliability across a huge existing toolset are your priority, Zapier Agents is hard to beat.
+
+## Where Taskade fits better
+
+If those three are so strong, where does Taskade win? Three places.
+
+### 1. The work lives where the agents run
+
+With an automation layer, your agent reaches across a connector to read your Gmail or write your Notion, and you manage state spread across separate apps. In Taskade, the projects, tasks, notes, and uploaded knowledge are *in the workspace* — so the agents already have native context. They don't fetch your data; they live in it. That removes a whole category of connector-syncing, context-loss, and "which app is the source of truth?" friction.
+
+See how that memory layer works in [What is an AI workspace?](../guides/ai-workspace.md) — it's the reason a workspace beats a stateless chatbot reaching across APIs.
+
+### 2. Multi-agent teams, not one agent per person
+
+Lindy gives each person an agent in their inbox. Gumloop and Zapier orchestrate steps. Taskade runs **multi-agent teams that share one memory and hand work to each other** — a researcher's output becomes the writer's input becomes the reviewer's queue — all over the same projects, sitting right next to your human teammates. It's a team of specialists collaborating on shared context, not a single assistant answering one prompt at a time.
+
+The [multi-agent workspace guide](../guides/multi-agent-workspace.md) goes deep on how shared memory and agent handoffs change what a team of agents can finish end to end.
+
+### 3. Genesis builds the app *and* the agents that run it
+
+This is the wedge none of the three has. Lindy Build makes agents. Gummie builds Gumloop workflows. Zapier Copilot builds Zaps. All of them generate automations that **point at your other tools.** **Taskade Genesis** generates the workspace app itself — database, UI, login/auth, payments, custom domain — *and* the AI agents and automations that run inside it. The app and its intelligence are born together.
+
+One enterprise customer who shipped a production business app this way put it plainly: *"What I accomplished in a few weeks would have taken a team of 40+ and 18 months in the Fortune 500."* That's not configuring an automation across apps — that's shipping the app. Walk through what Genesis produces in [Build AI agents for sales](../use-cases/ai-agents-for-sales.md), where the agents and the workspace they operate in are the same thing.
+
+## A note on pricing: workspace vs. per-activity credits
+
+This deserves its own moment, because it's where bills surprise people.
+
+Agent tools tend to meter by **activity or credits**, and autonomous agents are exactly the kind of thing that runs more than you expect. Zapier stacks an **"Activities" meter on top of its "Tasks"** plan, with per-run caps. Lindy meters credits (and bills voice per minute on top). Gumloop bundles LLM cost into credits. None of this is a gotcha — it's a reasonable way to price *consumption* — but it means an agent that decides to do extra work can cost extra money, and forecasting gets harder the more autonomous your agents are.
+
+Taskade uses a **workspace-centric model** where AI is included rather than metered per activity. For a team that wants agents running continuously without watching a credit counter, predictable workspace pricing is easier to live with. (As always: pricing changes — confirm current details on each vendor's site, including [Taskade's](https://www.taskade.com).)
+
+## Which should you choose?
+
+Be honest about the real job to be done.
+
+**Pick Lindy if:**
+- Your core need is autonomous email, scheduling, and **voice** handling.
+- You want one capable agent per person, operating your inbox.
+- You need to reach almost any tool, even ones without an API (Computer Use).
+
+**Pick Gumloop if:**
+- You want a **visual, no-code canvas** for multi-agent pipelines.
+- Model choice matters and you want **no vendor lock-in**.
+- You have enterprise security requirements (SOC 2 Type II, GDPR, VPC, RBAC).
+
+**Pick Zapier Agents if:**
+- **Integration breadth** is everything — you live across thousands of apps.
+- You value mature, **reliable** infrastructure and a long operational track record.
+- You're already deep in the Zapier ecosystem.
+
+**Pick Taskade if:**
+- You want agents, work, and apps in **one AI-native workspace**, not stitched across tools.
+- You want **multi-agent teams** with shared memory and handoffs, working beside humans.
+- You want to **describe an app and have it built** — agents included — with Genesis.
+- You prefer **predictable workspace pricing** over per-activity credit metering.
+
+**You might use more than one.** It's entirely reasonable to run Zapier Agents for cross-app automation against a massive existing stack *and* use Taskade as the AI-native home where your team actually works and ships apps. The tools aren't mutually exclusive — the question is where you want your work, your context, and your agents to live by default.
+
+## A 5-minute way to decide
+
+You don't need a feature spreadsheet. Ask one question:
+
+> **"Do I mostly need to *automate across the apps I already have*, or do I want a *home where work and agents live together*?"**
+
+- If the honest answer is *automate across my stack* — thousands of apps, autonomous email, cross-tool pipelines — lean toward Lindy, Gumloop, or Zapier Agents. That's the harness problem they were built for.
+- If the answer is *one place where agents, work, and apps co-exist* — shared memory, multi-agent teams, prompt-to-app — lean Taskade. That's the workspace problem it was built for.
+
+Most teams discover the answer shifts over time. They start wanting to automate connections between tools, and end up wanting fewer tools to connect — a single workspace where the work and the intelligence already share a home.
+
+## Common scenarios, mapped honestly
+
+| What you're trying to do | Better starting point | Why |
+|---|---|---|
+| Autonomously triage and reply to email; answer the phone | Lindy | Best-in-class autonomous email and sub-second voice (Gaia). |
+| Build a visual multi-agent pipeline with your choice of model | Gumloop | No-code canvas, multi-model, strong enterprise security. |
+| Automate actions across thousands of existing apps reliably | Zapier Agents | 9,000+ integrations on mature, proven infrastructure. |
+| Run a team of AI agents over shared project memory | Taskade | Multi-agent teams with handoffs are native, not bolted on. |
+| Ship a hosted app — database, auth, payments — from a prompt | Taskade | Genesis builds the app *and* the agents that run it. |
+| Keep your existing automation stack but add an AI-native home | Both | Automation layer for cross-app glue; Taskade for the workspace. |
+
+There's no shame in the rows that point to Lindy, Gumloop, or Zapier. Picking the right tool for the job is the entire point of an honest comparison.
+
+## Getting started in Taskade
+
+If you want to try the AI-native-workspace path, don't start by wiring connectors — start by describing the outcome.
+
+1. **Describe what you want.** Open [Genesis](https://www.taskade.com/ai/apps) and write it in plain English: "a sales workspace where agents research leads, draft outreach, and follow up when a deal goes quiet."
+2. **Let it build the workspace and the agents.** Genesis generates the projects, the multi-agent team, the automations, and (if you need one) a hosted app with auth and payments.
+3. **Run the team.** Watch agents share memory and hand work to each other over the same projects — no connector round-trips to reach your own data.
+4. **Add your stack as needed.** With 100+ integrations, pull in the tools you already use so agents can read and write them too — incrementally, not as a migration.
+
+For the deeper concept behind all of this, read [What is a multi-agent workspace?](../guides/multi-agent-workspace.md)
+
+## FAQ
+
+**What's the real difference between Taskade and tools like Lindy, Gumloop, or Zapier Agents?**
+Those are automation layers that act across your *other* apps, where your work still lives. Taskade is an AI-native workspace where agents, projects, docs, and the apps they build live together — so agents have native context, with predictable workspace pricing instead of per-activity credits.
+
+**Is Lindy better than Taskade for email and voice?**
+For purely autonomous email triage and voice calls, Lindy is excellent and arguably best-in-class — its Gaia voice agent and inbox automation are standouts. Taskade's strength is different: multi-agent teams that share memory and work alongside humans inside the same workspace, plus building hosted apps from a prompt. Match the tool to the job.
+
+**Does Gumloop or Zapier do multi-agent work?**
+Gumloop orchestrates multi-agent pipelines on a visual canvas, and Zapier coordinates agents calling actions across apps — both genuinely capable. The difference with Taskade is that its agents share one persistent workspace memory and hand tasks to each other over the same projects, rather than running steps against external tools.
+
+**Which has the most integrations?**
+Zapier, by a wide margin — 9,000+ integrations, the largest catalog in the category. Lindy lists 5,000+, Gumloop around 130, and Taskade 100+ (Taskade's own claim). If raw integration breadth is your deciding factor, Zapier Agents wins that row outright.
+
+**How does pricing compare?**
+Agent tools generally meter by credits or activities — Zapier even stacks a separate "Activities" meter on top of "Tasks," and Lindy bills voice per minute. Autonomous agents can consume those faster than expected. Taskade uses a workspace-centric model with AI included. Pricing changes, so confirm current details on each vendor's site.
+
+**Can Taskade build an app like these tools build automations?**
+That's the key difference. Those tools generate automations that point at your other apps. Taskade Genesis generates the workspace app itself — database, UI, auth, payments, custom domain — *and* the agents and automations that run inside it. See [Introducing Taskade Genesis](https://www.taskade.com/blog/introducing-taskade-genesis).
+
+**Should I switch, or can I run both?**
+You can run both. Keep an automation layer like Zapier Agents for cross-app glue and use Taskade as the AI-native home where your team works and ships apps. With 100+ integrations, Taskade can sit alongside your existing stack rather than replacing it overnight.
+
+## Related
+
+- [What is a multi-agent workspace?](../guides/multi-agent-workspace.md) — the deep dive on shared memory and agent handoffs
+- [What is an AI workspace?](../guides/ai-workspace.md) — why a memory layer beats a chatbot reaching across APIs
+- [AI agents for sales](../use-cases/ai-agents-for-sales.md) — multi-agent teams in action
+- [Compare hub](../compare/README.md) — every Taskade comparison in one place
+
+---
+
+**Ready to see agents, work, and apps in one place?** [Build your first app with Genesis](https://www.taskade.com/ai/apps) — describe it in plain English and watch the workspace come to life.

--- a/docs/compare/taskade-vs-asana.md
+++ b/docs/compare/taskade-vs-asana.md
@@ -36,7 +36,7 @@ We'll say it plainly: Asana is one of the most mature work-management platforms 
 - **AI embedded in the work graph.** Asana's AI isn't a detached chat panel bolted onto the side. It reads the existing work graph — projects, tasks, dependencies, and relationships — with full context, and it's permission-aware, so it respects who can see what. That's a meaningfully better foundation than a generic assistant.
 - **AI Studio for no-code automation.** AI Studio lets teams build agentic workflows and "AI Teammates" without code, running them against real project context. It's a serious, well-integrated capability.
 - **Enterprise governance and reporting.** Mature admin controls, granular permissions, universal reporting, and audit features built for large, governed organizations. If compliance and oversight matter, Asana is built for it.
-- **Roadmap signal.** Asana acquired **StackAI in May 2026** to run agent workflows across enterprise systems — a clear bet on agents reaching beyond Asana's own walls.
+- **Roadmap signal.** Asana has reportedly acquired StackAI (2026) to run agent workflows across enterprise systems — a signal it's betting on agents reaching beyond its own walls. Check Asana's site for the latest.
 
 If you run a large portfolio with real governance requirements and a team to administer it, Asana rewards that investment.
 

--- a/docs/compare/taskade-vs-asana.md
+++ b/docs/compare/taskade-vs-asana.md
@@ -1,0 +1,164 @@
+# Taskade vs Asana: An Honest Comparison (and Asana Alternative Guide)
+
+If you're weighing an **Asana alternative**, the question usually isn't "which tool has more features." Asana has plenty. The real question is what you're trying to do next. Asana is built to run large, structured work across many teams and report on it cleanly. Taskade is built so AI agents do real work and you can ship apps without engineers.
+
+This page is written to be fair. Asana is a genuinely strong, mature platform, and for a lot of organizations it's the right call. Below we lay out where each tool actually wins, so you can decide based on how you work — not on a feature-count race.
+
+[![Track projects across multiple views in Taskade](../../media/apps/project-tracker.gif)](https://www.taskade.com)
+
+> Short version: **Asana** is deep enterprise work and portfolio management with AI now embedded in its work graph. **Taskade** is an AI-native workspace where memory (projects + notes), intelligence (multi-agent teams), and execution (automations + Taskade Genesis apps) live together. If you need governance-heavy portfolio management at scale, Asana is excellent. If you want AI agents that do the work and a path to ship apps without code, Taskade fits better.
+
+---
+
+## At a glance
+
+| Dimension | Taskade | Asana |
+| --- | --- | --- |
+| **AI & agents** | AI-native core. Custom multi-agent teams you train on your own data, with model choice and tools. | AI embedded in the work graph — AI Studio (no-code agent/workflow builder) and AI Teammates, with full project context. |
+| **Multi-agent** | Multi-agent workspaces — agents collaborate, hand off, and run as a team. | AI Teammates and AI Studio workflows; oriented around automating the existing work graph rather than teams of collaborating agents. |
+| **AI pricing model** | AI is included in the workspace; paid plans add more usage. | Per-seat tiered pricing, with AI Studio sold as a **credit-metered add-on on top of seats**. AI is not fully bundled. |
+| **App-building** | Genesis: describe an app in plain English → hosted app with database, auth, payments, UI, custom domain. | Not an app builder. You configure Asana; you don't ship standalone hosted apps. |
+| **Project / portfolio depth** | 7 views: List, Board, Calendar, Table, Mind Map, Gantt, Org Chart. Lighter structure. | Timeline/Gantt, Workload, Goals/OKRs, Portfolios — genuinely deep, mature portfolio management. |
+| **Enterprise governance** | Lighter, faster time-to-value. | Mature admin, permissions, reporting, and audit — built for large, governed orgs. |
+| **Simplicity / onboarding** | Fast to start; plain-English setup; sensible defaults. | Powerful but heavier; more setup and administration before it fits a large org. |
+| **Pricing** | Free tier; paid plans add more AI usage, agents, and automation runs. | Free Personal tier; Starter / Advanced / Enterprise per seat, plus metered AI Studio. (Check each site for current pricing.) |
+| **Best for** | AI-first teams that want agents and app-building without enterprise lift. | Large organizations running governance-heavy portfolio management at scale. |
+
+*Feature availability and pricing change often, and vendors revise both regularly. Verify current details on [taskade.com](https://www.taskade.com) and asana.com before deciding.*
+
+---
+
+## Where Asana shines
+
+We'll say it plainly: Asana is one of the most mature work-management platforms available, and for large, structured organizations its depth is a real advantage. If your decision hinges on portfolio management and governance, this is its home turf.
+
+- **Deep project and portfolio management.** Timeline and Gantt, Workload (capacity planning across people), Goals and OKRs, and Portfolios that roll many projects up into one executive view. For organizations coordinating dozens of teams, this depth is legitimate and hard to match.
+- **AI embedded in the work graph.** Asana's AI isn't a detached chat panel bolted onto the side. It reads the existing work graph — projects, tasks, dependencies, and relationships — with full context, and it's permission-aware, so it respects who can see what. That's a meaningfully better foundation than a generic assistant.
+- **AI Studio for no-code automation.** AI Studio lets teams build agentic workflows and "AI Teammates" without code, running them against real project context. It's a serious, well-integrated capability.
+- **Enterprise governance and reporting.** Mature admin controls, granular permissions, universal reporting, and audit features built for large, governed organizations. If compliance and oversight matter, Asana is built for it.
+- **Roadmap signal.** Asana acquired **StackAI in May 2026** to run agent workflows across enterprise systems — a clear bet on agents reaching beyond Asana's own walls.
+
+If you run a large portfolio with real governance requirements and a team to administer it, Asana rewards that investment.
+
+---
+
+## A precise word on Asana's AI pricing
+
+This matters enough to call out on its own, because it's easy to get wrong in either direction.
+
+Asana's AI is genuinely well-built and context-aware — that part is real. But it isn't simply "included." Asana's core pricing is **per-seat and tiered** (a free Personal tier, then Starter, Advanced, and Enterprise). On top of that, **AI Studio is a credit-metered add-on**: a Basic level is available with rate limits, while higher Plus and Pro tiers are sold as paid credit packages. So the honest framing is: you pay per seat **and** you meter AI usage separately on top.
+
+That's not a criticism — metered AI is a defensible model, and it lets heavy users pay for what they use. But if you're comparing tools, don't read "Asana has AI" as "AI is fully bundled." Taskade takes the other approach: AI is part of the workspace, and paid plans simply add more usage rather than charging a separate per-credit meter on top of seats. Neither is automatically cheaper — it depends on your usage. Check both vendors' current pricing pages before you decide.
+
+---
+
+## Where Taskade fits better
+
+Taskade isn't trying to out-depth Asana on portfolio management. It's built around a different idea: the workspace should *do work*, not just hold and report on it.
+
+- **AI-native, not AI-embedded-in-PM.** Asana embedded AI into an existing work-management product, and did it well. Taskade was designed around AI from the core, so agents, memory, and automation are how the product works — not a layer added to a project tool. See [the AI workspace pillar](../guides/ai-workspace.md).
+- **Multi-agent teams that DO the work.** Instead of automating an existing work graph, you can run a *team* of agents that collaborate and hand off — a researcher feeding a writer feeding a reviewer — with shared memory across the workspace. Read [what a multi-agent workspace is](../guides/multi-agent-workspace.md).
+- **Genesis apps.** This is the biggest difference. With [Taskade Genesis](https://www.taskade.com/ai/apps), you describe an app in plain English and get a complete, hosted, working app — database, AI agents, automations, UI, login/auth, payments, and a custom domain. Asana configures *itself*; Genesis ships a *product*. See it work in [build a CRM with AI](../genesis/build-a-crm-with-ai.md).
+- **Faster time-to-value.** The fastest path from idea to running system is plain English. Asana's depth is powerful but front-loaded with setup and administration; Taskade's lighter surface gets a team — or an app — running this week.
+
+One enterprise customer described shipping a production business app solo with Genesis this way: *"What I accomplished in a few weeks would have taken a team of 40+ and 18 months in the Fortune 500."* We share that not as a benchmark you should expect, but as an honest signal of what "build without engineers" can look like in practice.
+
+---
+
+## How they compare in practice
+
+Feature tables only get you so far. Here's how the two tools tend to feel across the work people actually do.
+
+**Standing up a new initiative.**
+In Asana, you'll typically create a project, choose a structure, set up fields and dependencies, and slot it into a portfolio so it reports cleanly upward. That structure pays off when leadership needs visibility across many teams — but it's front-loaded. In Taskade, you start typing, or you ask an agent to draft the structure, and refine as you go. Asana asks you to design the system; Taskade lets you start using it.
+
+**Getting AI to help.**
+Asana's AI is context-aware and permission-aware: AI Studio can build workflows and AI Teammates that act on your real project graph, which is a strong model — just remember it's metered on top of seats. In Taskade, AI is the substrate. You can stand up a dedicated agent, train it on your own documents, choose its model, and give it tools, with usage included in the workspace. The mental model shifts from "AI that understands my projects" to "a team of teammates I assign work to."
+
+**Managing a large portfolio.**
+This is Asana's home turf. Workload, Goals, Timeline, and Portfolios are built for coordinating and reporting across many teams at once. If that's your core job, Asana is deeper here, and we won't pretend otherwise. Taskade covers project work well with 7 views, but it's lighter on executive portfolio rollups and capacity planning.
+
+**Shipping something for people outside the team.**
+This is where the products diverge most. Asana is for running work *inside* an organization. When you need a customer-facing app — a portal, a storefront, an intake tool with its own login and payments — Asana isn't built for that. Genesis is. You describe the app and it's hosted, with a database and auth, on a domain you can share.
+
+---
+
+## A fair word on enterprise depth vs. speed
+
+This isn't a knock — it's a trade-off worth naming. Asana's strength is governed depth: portfolios, workload, goals, mature permissions, and reporting that hold up across a large organization. That depth requires administration and onboarding, and some of it goes unused on smaller teams.
+
+Taskade makes the opposite bet: lighter structure, stronger defaults, AI included in the workspace, and a path to ship real apps from plain English. That bet costs you some enterprise governance and portfolio reporting. If you're a large org with real oversight requirements, Asana's depth may matter more than Taskade's speed. If your goal is to get agents — or an app — *running* this week without an enterprise rollout, the lighter surface tends to win.
+
+Neither bet is "right." They serve different goals. Pick the one that matches yours.
+
+---
+
+## Which should you choose?
+
+**Choose Asana if:**
+
+- You run governance-heavy portfolio management across many teams and need executive rollups.
+- Workload/capacity planning, Goals/OKRs, Timeline, and Portfolios are core to how you operate.
+- You want AI embedded in a mature work graph and are comfortable metering AI Studio credits on top of per-seat pricing.
+- You have admins to own setup, permissions, and reporting at scale.
+
+**Choose Taskade if:**
+
+- You want AI agents that actually do work — research, drafting, triage, execution — with AI included in the workspace.
+- You want multi-agent teams that collaborate and hand off, not a single assistant.
+- You want to ship apps without engineers, in weeks not months, with no code.
+- You value fast time-to-value over enterprise configuration, and non-technical people need to build and run real things on their own.
+
+**Honest middle ground:** some organizations keep Asana for heavy structured portfolio management and use Taskade for AI agents, automations, and app-building. There's no rule that says you must pick exactly one — match each tool to the job it's best at.
+
+---
+
+## What teams move to Taskade for
+
+If you're evaluating a switch, these are the jobs where people most often find Taskade pulls ahead. Each links to a hands-on guide.
+
+- **A coordinated agent team.** Multiple agents that pass work between them — research, drafting, review. See [the multi-agent workspace guide](../guides/multi-agent-workspace.md).
+- **A real, shippable app.** A CRM, client portal, or storefront built from a plain-English description and hosted on your own domain, via [Taskade Genesis](https://www.taskade.com/ai/apps). Worked example: [build a CRM with AI](../genesis/build-a-crm-with-ai.md).
+- **AI included, not metered separately.** A workspace where agents and automations are part of the product rather than a credit add-on layered on seats.
+- **A faster general workspace.** Notes, tasks, and 7 views without the administration overhead — a lighter home base for everyday work. See [what an AI-native workspace is](../guides/ai-workspace.md).
+
+You don't need to commit your whole org on day one. Pick one of these, run it in Taskade for a couple of weeks, and compare it honestly against how the same job feels in Asana.
+
+---
+
+## FAQ
+
+**Is Taskade a real Asana alternative?**
+Yes, for most teams — especially if AI agents and app-building matter to you. Taskade covers core project work (tasks, notes, and 7 views including List, Board, Calendar, Table, Mind Map, Gantt, and Org Chart) and adds multi-agent teams, automations, and Genesis app-building. It's lighter on advanced portfolio management, capacity planning, and enterprise reporting than Asana.
+
+**Does Asana have AI agents?**
+Yes. Asana's AI is embedded in its work graph, with AI Studio (a no-code agent and workflow builder) and AI Teammates that act on your real project context. It's well-integrated and permission-aware. The thing to watch on cost: AI Studio is a credit-metered add-on on top of per-seat pricing, not fully bundled.
+
+**Is Asana's AI included in the price?**
+Not fully. Asana's core plans are per-seat and tiered, and AI Studio is sold as a credit-based add-on on top (a Basic level with rate limits, then paid Plus/Pro credit tiers). Taskade includes AI in the workspace and adds more usage on paid plans. Check both vendors' current pricing before deciding, since usage patterns change the math.
+
+**Can Taskade replace Asana's portfolio management and reporting?**
+Partly. Taskade has views and tables that cover common tracking needs, but if your team relies on Workload, Goals/OKRs, Timeline, and Portfolio rollups across many teams, Asana is currently deeper there. Be honest about how much of that depth you actually use.
+
+**What can Taskade do that Asana can't?**
+Two big things: **multi-agent teams** that collaborate on work with shared memory, and **Genesis** — building a complete, hosted app (database, auth, payments, UI, custom domain) from a plain-English description. Asana is a platform you configure; Genesis ships a standalone product. See [Genesis](https://www.taskade.com/blog/introducing-taskade-genesis).
+
+**Is migrating from Asana hard?**
+Most teams start small: move one project or stand up one agent in Taskade, run it alongside Asana, and expand from there. You don't have to migrate everything at once.
+
+**Do I need to be technical to use Taskade?**
+No. The whole point is plain English. If you can describe what you want, you can build agents, automations, and apps.
+
+---
+
+## Related
+
+- [What a multi-agent workspace is](../guides/multi-agent-workspace.md)
+- [What is Taskade Genesis](../genesis/what-is-taskade-genesis.md)
+- [Build a CRM with AI](../genesis/build-a-crm-with-ai.md)
+- [What an AI-native workspace is](../guides/ai-workspace.md)
+- [Compare all Taskade alternatives](../compare/README.md)
+
+---
+
+**Ready to try the AI-native approach?** Build your first agent or app free at [taskade.com](https://www.taskade.com) — or describe an app in plain English with [Taskade Genesis](https://www.taskade.com/ai/apps).

--- a/docs/compare/taskade-vs-coda.md
+++ b/docs/compare/taskade-vs-coda.md
@@ -1,0 +1,169 @@
+# Taskade vs Coda: An Honest Comparison (and Coda Alternative Guide)
+
+If you're weighing a **Coda alternative**, you already know the appeal of Coda: it turns a document into something that behaves like an app — tables, formulas, buttons, and connected data all living on one page. That's a genuinely powerful idea, and Coda does it better than almost anyone.
+
+Taskade makes a different bet. Instead of asking you to assemble an app by hand from formulas and building blocks, Taskade is an **AI-native workspace** where you describe what you want in plain English and **Taskade Genesis** builds a complete, hosted app for you — with AI agents and automations running inside it.
+
+This page is written to be fair. Coda is an excellent product, and for power users who love building custom doc-tooling, it may be the better tool. Below we lay out where each one genuinely wins, so you can decide based on how you actually work.
+
+[![Build a complete app from a plain-English prompt with Taskade Genesis](../../media/genesis/app-builder.gif)](https://www.taskade.com/ai/apps)
+
+> Short version: **Coda** is a doc-database hybrid — "docs that act like apps" — that you assemble yourself from tables, formulas, buttons, and Packs. **Taskade** is an AI-native workspace where memory (projects + notes), intelligence (multi-agent teams), and execution (automations + Genesis apps) live together. If you love hand-crafting formula-driven internal tools, Coda is a more powerful canvas. If you want AI to *build the thing* and run agents inside it, Taskade fits better.
+
+---
+
+## At a glance
+
+| Dimension | Taskade | Coda |
+| --- | --- | --- |
+| **Core model** | AI-native workspace + prompt-to-hosted-app (Genesis). | Doc-database hybrid: documents that behave like apps. |
+| **Building approach** | Describe the app in plain English; Genesis builds it. | A human assembles tables, formulas, buttons, and Packs by hand. |
+| **AI & agents** | AI-native core: custom multi-agent teams with shared memory and tools. | Coda AI (Chat / Assistant / Column) and Coda Brain — credit-metered per Doc Maker. |
+| **Multi-agent** | Multi-agent workspaces — agents collaborate, hand off, and run as a team. | Single-assistant style AI; not designed around teams of agents working together. |
+| **App output** | A standalone, hosted app with login/auth, payments, and a custom domain. | An interactive doc that lives inside Coda. |
+| **Automations** | Visual automation flows plus an AI workflow generator; describe it, get a flow. | Automations and buttons inside a doc; mature and flexible for in-doc logic. |
+| **Integrations** | 100+ integrations (Taskade's claim) — Slack, Stripe, Gmail, Notion, and more. | 600+ Packs — a large, well-established connector ecosystem. |
+| **In-app payments** | Yes — Genesis apps support Stripe-backed checkout and paywalls out of the box. | No native customer-facing payment app; you'd connect external tooling. |
+| **Pricing model** | Workspace-centric: free tier; paid plans add AI usage, agents, and runs. | Per-Doc-Maker (creators pay; editors/viewers free) plus an AI credit system. |
+| **Best for** | Teams that want AI to build the app and run agents inside it. | Power users who love formula-driven, custom doc-tooling without code. |
+
+*Feature availability and pricing change often, and Coda's product is mid-transition (see below). Verify current details on [taskade.com](https://www.taskade.com) and coda.io before deciding.*
+
+---
+
+## Where Coda shines
+
+We'll say it plainly: Coda's core idea is excellent, and the execution is mature. If your decision hinges on hand-built, structured-data tooling, this is its home turf.
+
+- **The doc-as-app model.** Coda blends a writing surface with structured data in a way few tools match. A single doc can hold rich text, multiple linked tables, formulas, and interactive buttons — so a "document" becomes a small internal tool. For bespoke workflows, this flexibility is real.
+- **Formulas and structured data.** Coda's formula language is powerful. If you think in spreadsheets and want logic that reacts to your data — rollups, conditional views, computed columns, automations triggered by buttons — Coda gives you a deep, expressive canvas.
+- **Packs.** Coda offers **600+ Packs** — connectors that pull live data from other tools into your doc and let buttons push actions back out. The ecosystem is broad and well-established.
+- **Custom internal tools without code.** For a builder who enjoys assembling the pieces, Coda can replace a pile of one-off spreadsheets and small apps with a single, tailored doc. That's a legitimately strong outcome.
+
+If you have someone who *enjoys* building with formulas and wants precise control over a custom doc-tool, Coda rewards that investment.
+
+A fair point worth repeating: for deeply customized, formula-driven, structured-data internal tooling, Coda remains a more powerful **builder canvas** than Taskade. We're not going to pretend otherwise.
+
+---
+
+## Where Taskade fits better
+
+Taskade isn't trying to out-formula Coda. It's built around a different idea: you shouldn't have to assemble the app yourself — you should be able to *describe it* and have it built, with intelligence already inside.
+
+- **AI-native, not AI-added.** Taskade was designed around AI from the core, so agents, memory, and automation aren't features bolted onto a doc — they're how the product works. See [the AI workspace pillar](../guides/ai-workspace.md).
+- **Describe it instead of building it.** This is the biggest difference. With [Taskade Genesis](https://www.taskade.com/ai/apps), you describe an app in plain English and get a complete, hosted, working app — database, AI agents, automations, UI, login/auth, payments, and a custom domain. In Coda, *you* assemble the tables, formulas, and buttons. With Genesis, the workspace builds it for you, then you refine it by clicking.
+- **A real standalone app, not a doc.** A Coda build lives inside Coda as an interactive document. A Genesis app is standalone software at a live URL — with its own login, its own data, and the option to run on your own domain. See [what Taskade Genesis builds](../genesis/what-is-taskade-genesis.md).
+- **Multi-agent teams that take action.** Instead of an AI assistant that helps you edit a doc, Taskade lets you run a *team* of agents that collaborate and hand off work — a researcher feeding a writer feeding a reviewer — with shared, persistent memory. Read [what a multi-agent workspace is](../guides/multi-agent-workspace.md).
+- **Start from a finished app, not a blank doc.** You can clone a live community app kit in about a minute — data, agents, and automations already wired up — then make it yours. See [clone-ready app kits](../genesis/app-kits.md).
+
+One enterprise customer described shipping a production business app solo with Genesis this way: *"What I accomplished in a few weeks would have taken a team of 40+ and 18 months in the Fortune 500."* We share that not as a benchmark you should expect, but as an honest signal of what "build without engineers" can look like in practice.
+
+---
+
+## A note on AI: included vs metered
+
+It's worth being precise here, because "AI is included" gets thrown around loosely.
+
+**Coda AI** — Chat, the in-line Assistant, and AI-powered columns — is available to Doc Makers as part of the product rather than a fully separate license. That's a reasonable model. But it's **credit-metered**: AI usage draws down credits (roughly one credit per ~40 characters generated, per Coda's documentation), and heavier use means buying credit packs or an unlimited-AI add-on. So "included" doesn't mean "unlimited." If your team runs AI hard, you're metering it.
+
+**Taskade** includes AI in the workspace itself — agents, automations, and the workflow generator are part of how the product works, with paid plans adding more usage, more agents, and more automation runs. The model is workspace-centric rather than per-document-credit. (As always, verify current limits on each vendor's pricing page.)
+
+The honest summary: both tools give you AI without a wholly separate AI seat, but Coda meters it by credit. Don't assume Coda AI is unlimited.
+
+---
+
+## Roadmap stability: an honesty flag
+
+This is the part you should check yourself before deciding, because the public picture is unsettled and parts of it come from secondary reporting rather than Coda's own announcements.
+
+- Coda was **acquired by Grammarly**. That much is established.
+- **Reportedly, as of 2026**, Grammarly rebranded its parent company to **Superhuman**, and Coda is positioned as the workspace component of that broader suite. This rebrand has been reported by secondary sources (around late 2025) rather than confirmed here from a primary Coda acquisition post.
+- Also **reportedly**, the standalone **Coda Brain** / Coda AI capabilities have been folded into **Superhuman Go**. We're flagging this as secondary-sourced, not confirmed fact.
+
+We're being explicit about the uncertainty on purpose. Product names, packaging, and AI features under an active rebrand can change quickly. **Check Coda's and Superhuman's current pages before you commit** — don't treat "Coda Brain as a standalone product" as a given, and don't assume the branding you read elsewhere still matches what's live.
+
+By contrast, Taskade's roadmap is a stable, AI-native one: the workspace, the multi-agent layer, and Genesis are the through-line, not a product in the middle of being absorbed into a larger suite.
+
+---
+
+## How they compare in practice
+
+Feature tables only get you so far. Here's how the two tools tend to feel across the work people actually do.
+
+**Building an internal tool.**
+In Coda, you start with a doc, add tables, write formulas, wire up buttons, and connect Packs until the doc behaves like the tool you wanted. It's powerful, and for someone who enjoys it, it's satisfying. In Taskade, you describe the tool in plain English and Genesis generates it — database, UI, and the agents that operate it — then you refine by clicking. Coda asks you to *assemble*; Genesis asks you to *describe*.
+
+**Getting AI to help.**
+Coda AI can draft text, fill columns, and answer questions about your doc — useful, and metered by credit. In Taskade, AI is the substrate: you can stand up a dedicated agent, train it on your own documents, choose its model, and give it tools so it can take actions, not just respond. The mental model shifts from "an assistant inside my doc" to "a team of teammates I assign work to."
+
+**Shipping something for people outside the team.**
+This is where the products diverge most. A Coda build is an interactive document that lives inside Coda. When you need a customer-facing app — a portal, a storefront, an intake tool with its own login and payments — that's a different kind of artifact. Genesis ships exactly that: a hosted app with auth, a database, Stripe-backed payments, and a custom domain. See a worked example in [build a CRM with AI](../genesis/build-a-crm-with-ai.md).
+
+**Connecting your other tools.**
+Both tools connect to your stack. Coda's **600+ Packs** are a genuine strength and a broader catalog than Taskade's **100+ integrations**. If raw connector count is your deciding factor, Coda is ahead. Taskade's edge isn't breadth — it's that agents and automations use those connections to *act* on your behalf inside the workspace.
+
+---
+
+## A fair word on the build-it-yourself trade-off
+
+This isn't a knock — it's a trade-off worth naming. Coda's strength is that you build precisely what you want, formula by formula. The flip side is that you have to build it: someone has to design the tables, write the logic, and maintain it as needs change. Many builders love that control. Others want the outcome without becoming the maintainer of a custom doc.
+
+Taskade makes the opposite bet: describe the outcome, let AI build and wire it, and refine by clicking. That bet costs you some of Coda's fine-grained, formula-level control. If your tooling is unusual and you want to hand-tune every cell and rule, Coda's canvas may matter more. If your goal is to get a real app — with agents and payments — *running* this week, the describe-it path tends to win.
+
+Neither bet is "right." They serve different goals. Pick the one that matches yours.
+
+---
+
+## Which should you choose?
+
+**Choose Coda if:**
+
+- You love building with formulas, tables, and buttons, and want precise control over a custom doc-tool.
+- Your tooling lives naturally as a document — structured data plus rich text on one surface.
+- You rely on a broad connector ecosystem (Packs) and enjoy assembling the pieces yourself.
+- You're comfortable with credit-metered AI and a per-Doc-Maker pricing model.
+
+**Choose Taskade if:**
+
+- You want to describe an app in plain English and have it built — database, UI, auth, and payments included.
+- You want AI agents that actually do work — research, drafting, triage, execution — not just edit a doc.
+- You want to ship standalone, hosted apps without engineers, in weeks not months, with no code.
+- You'd rather not bet on a product mid-transition, and want a stable AI-native roadmap.
+
+**Honest middle ground:** some teams keep Coda for a few beloved formula-heavy internal docs and use Taskade for AI agents, automations, and shipping real customer-facing apps. There's no rule that says you must pick exactly one — match each tool to the job it's best at.
+
+---
+
+## FAQ
+
+**Is Taskade a real Coda alternative?**
+Yes, for most teams — especially if AI and shipping real apps matter to you. Coda builds "docs that act like apps" by hand with formulas and Packs; Taskade Genesis turns a plain-English prompt into a standalone hosted app, and agents are first-class across the workspace. Coda's product is also mid-transition under the Superhuman/Grammarly umbrella, which is worth weighing.
+
+**Does Coda build real, standalone apps?**
+Coda builds interactive documents that behave like apps, but they live inside Coda. Taskade Genesis builds a standalone, hosted app — its own URL, login/auth, database, Stripe payments, and a custom domain. Different artifacts: a powerful doc versus running software you can hand to customers.
+
+**Is Coda AI included or metered?**
+Coda AI is available to Doc Makers as part of the product, but it's **credit-metered** (roughly one credit per ~40 characters, per Coda's docs), with credit packs or an unlimited add-on for heavy use. So it's "included" within limits, not unlimited. Taskade includes AI in the workspace with paid plans adding more usage.
+
+**What about the Coda / Grammarly / Superhuman situation?**
+Coda was acquired by Grammarly. Reportedly, as of 2026, the parent rebranded to Superhuman and Coda Brain folded into Superhuman Go — but that's from secondary sources, not confirmed here. Check Coda's and Superhuman's live pages before deciding; names and AI packaging can shift during an active rebrand.
+
+**Does Coda have more integrations than Taskade?**
+Yes — Coda lists 600+ Packs, a broader connector catalog than Taskade's 100+ integrations. Taskade's advantage isn't breadth but that agents and automations use those connections to take action inside the workspace, not just pull data into a doc.
+
+**Do I need to be technical to use Taskade?**
+No. The whole point is plain English. If you can describe what you want, you can build agents, automations, and apps with [Taskade Genesis](https://www.taskade.com/blog/introducing-taskade-genesis) — no formulas required.
+
+---
+
+## Related
+
+- [What Taskade Genesis builds](../genesis/what-is-taskade-genesis.md)
+- [The AI workspace pillar](../guides/ai-workspace.md)
+- [Clone-ready app kits](../genesis/app-kits.md)
+- [Taskade vs Notion](../compare/taskade-vs-notion.md)
+- [Compare hub: all Taskade alternatives](../compare/README.md)
+
+---
+
+**Ready to try the AI-native approach?** Describe an app in plain English and watch it build with [Taskade Genesis](https://www.taskade.com/ai/apps) — or start free at [taskade.com](https://www.taskade.com).

--- a/docs/compare/taskade-vs-coda.md
+++ b/docs/compare/taskade-vs-coda.md
@@ -18,7 +18,7 @@ This page is written to be fair. Coda is an excellent product, and for power use
 | --- | --- | --- |
 | **Core model** | AI-native workspace + prompt-to-hosted-app (Genesis). | Doc-database hybrid: documents that behave like apps. |
 | **Building approach** | Describe the app in plain English; Genesis builds it. | A human assembles tables, formulas, buttons, and Packs by hand. |
-| **AI & agents** | AI-native core: custom multi-agent teams with shared memory and tools. | Coda AI (Chat / Assistant / Column) and Coda Brain — credit-metered per Doc Maker. |
+| **AI & agents** | AI-native core: custom multi-agent teams with shared memory and tools. | Coda AI (Chat / Assistant / Column), plus Coda Brain (reportedly folding into Superhuman Go — verify) — credit-metered per Doc Maker. |
 | **Multi-agent** | Multi-agent workspaces — agents collaborate, hand off, and run as a team. | Single-assistant style AI; not designed around teams of agents working together. |
 | **App output** | A standalone, hosted app with login/auth, payments, and a custom domain. | An interactive doc that lives inside Coda. |
 | **Automations** | Visual automation flows plus an AI workflow generator; describe it, get a flow. | Automations and buttons inside a doc; mature and flexible for in-doc logic. |

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,135 @@
+# Taskade Genesis FAQ
+
+Short, direct answers to the questions people actually ask about Taskade Genesis and the AI-native workspace it lives in — what it builds, how AI agents work, how it compares to other tools, and how pricing, data, and integrations work. Where a question needs more depth, follow the link to its full page. Pricing changes, so we describe the model here and defer exact numbers to [taskade.com](https://www.taskade.com).
+
+[![Describe an app and Taskade Genesis builds it](../media/genesis/app-builder.gif)](https://www.taskade.com/ai/apps)
+
+## Taskade Genesis basics
+
+### What is Taskade Genesis?
+
+Taskade Genesis is an AI app builder that turns a plain-English description into a complete, hosted, working application — database, AI agents, automations, UI, login and auth, payments, and a custom domain. It produces a real running app, not a mockup.
+
+### How does Taskade Genesis work?
+
+You open the builder, describe the outcome in plain English, and Genesis generates the projects, agent roles, automations, and UI. You run it, refine it in click-to-edit (changes are live immediately), then share with your team or publish on a custom domain.
+
+### Can I build an app without code?
+
+Yes. With Taskade Genesis you describe the app in plain English and it builds a complete, hosted application — database, agents, automations, UI, login, payments, and a custom domain — with no code and no setup.
+
+### Who is Taskade Genesis for?
+
+It's for operators, founders, and non-technical builders who know what they want shipped but don't write code — the "build without permission" idea: no ticket, no sprint, no engineer required to get a real tool live.
+
+### Is the app actually hosted, or just a prototype?
+
+It's a real hosted app at a live URL with login/auth built in, and it can run on your own custom domain. It's running software your team or customers can use, not a static prototype.
+
+### Can I take payments inside an app I build?
+
+Yes. Genesis apps support Stripe-backed checkout and paywalls built in, so an app can charge a customer, log the order, and email a receipt without bolting on third-party payment tools or hiring an engineer.
+
+### Can I clone an existing app instead of starting from a blank prompt?
+
+Yes. You can clone a live community app kit in about a minute — data, AI agents, and automations already wired up — then rename it, add your data, add a login, and publish on your own domain. Taskade lists 150+ community kits.
+
+### What's the difference between vibe coding and what Genesis does?
+
+Vibe coding (popularized by Andrej Karpathy in Feb 2025) means describing what you want in natural language and letting AI build it. Genesis goes further: apps ship with built-in intelligence — agents, automations, a database — not just code files.
+
+## AI workspace and agents
+
+### What is an AI workspace?
+
+An AI workspace is a single place where your information, your AI, and your work live together, so asking for something and getting it done are the same motion. Taskade frames it as Memory + Intelligence + Execution in one workspace.
+
+### What does "AI-native" mean versus AI bolted onto an old tool?
+
+AI-native means AI is the substrate, not a side feature: agents share your data, take actions, and produce output back inside the workspace. AI "bolted on" is a chat panel that forgets context between sessions and only returns text you must act on yourself.
+
+### What is Workspace DNA?
+
+Workspace DNA is Taskade's term for the three interconnected pillars that make a workspace "alive": Memory (projects and notes), Intelligence (multi-agent teams), and Execution (automations and Genesis apps), running as one feedback loop rather than separate tools.
+
+### What is a multi-agent workspace?
+
+A multi-agent workspace is a team of AI agents that share one memory, hand tasks to each other, and finish a job end to end — a researcher, a writer, a reviewer working the same projects, rather than a single chatbot answering one question at a time.
+
+### Why use multiple agents instead of one AI assistant?
+
+A single assistant forgets between sessions, does one thing at a time, and only returns text. Specialized agents keep persistent shared memory, each own one focused job, and can take real action — creating tasks, filling databases, and triggering automations.
+
+### What can AI agents actually do besides chat?
+
+They create and complete tasks, fill databases, read and write your connected tools, send messages and emails, run automations, and operate inside Genesis apps. They execute work rather than only suggesting it.
+
+### What is agent memory?
+
+Agent memory is the shared, persistent context your agents draw on — your projects, notes, uploaded documents, and past conversations — so you stop re-explaining your business every session and agents produce work specific to your real context.
+
+### Can AI agents work alongside my human team?
+
+Yes. Agents live in the same projects your team uses — they can be assigned tasks, comment, complete work, and trigger the next step, sitting right next to human teammates instead of in a separate app.
+
+## Comparisons
+
+### Is Taskade a Notion alternative?
+
+Yes — but a structurally different one. Notion is document-first; Taskade is AI-native, with multi-agent teams, built-in automations, and Genesis (prompt-to-hosted-app with database, auth, payments, and a custom domain). Notion isn't designed to ship standalone apps.
+
+### Is Taskade an Asana alternative?
+
+Yes. Asana is deep enterprise work and portfolio management; Taskade is an AI-native workspace with native multi-agent teams and Genesis app-building. Asana layers AI Studio on top of per-seat pricing as metered credits, while Taskade includes AI in the workspace.
+
+### Is Taskade a Coda alternative?
+
+Yes. Coda builds "docs that act like apps" by hand with formulas and Packs; Taskade Genesis turns a plain-English prompt into a standalone hosted app, and agents are first-class across the workspace. Coda's product is also mid-transition under the Superhuman/Grammarly umbrella.
+
+### Is Taskade an Airtable alternative?
+
+Yes. Airtable is a powerful database/spreadsheet tool; Taskade adds AI agents that read and write your data, automations described in plain English, and Genesis to turn that data into a hosted app — not just a structured table.
+
+### How is Taskade different from AI agent tools like Lindy, Gumloop, or Zapier?
+
+Those are automation layers that act across your other apps, where your work still lives. Taskade is an AI-native workspace where agents, projects, docs, and the apps they build live together — so agents have native context, with predictable workspace pricing instead of per-activity credits.
+
+### What does Taskade do that Notion and ClickUp don't?
+
+Two things stand out: multi-agent teams that take real action, and Genesis — building a complete hosted app (database, auth, payments, UI, custom domain) from a plain-English description. Those tools configure themselves; Genesis ships a product.
+
+### Should I switch from my current tool to Taskade?
+
+You don't have to rip anything out to start. With 100+ integrations Taskade can sit alongside the tools you already run and pull their data into shared memory, so you can adopt it incrementally rather than migrating everything at once.
+
+## Pricing, data, and integrations
+
+### Is Taskade free?
+
+Yes — Taskade has a free tier, and plans start at $0/month. Paid plans add more AI usage, agents, and automation runs. Always check taskade.com for current pricing.
+
+### Is Taskade Genesis free to try?
+
+Yes, you can start building from a prompt for free. Higher AI usage, more agents, and more automation runs come with paid plans; verify the current details on taskade.com.
+
+### What integrations does Taskade support?
+
+Taskade supports 100+ integrations, covering the common stack — Slack, Stripe, Shopify, Gmail, Google Calendar, Google Drive, Google Sheets, Notion, HubSpot, GitHub, Discord, and more. Connect a tool once and your agents and flows can read and write to it.
+
+### What is MCP (Model Context Protocol)?
+
+MCP is a shared standard for plugging tools into AI — Taskade describes it as "USB-C for AI tools." A tool that speaks the standard can connect to your agents without a bespoke build, and Taskade can both use connected tools and be a tool other AI systems connect to.
+
+### Is my data private and secure in Taskade?
+
+Your workspace is yours. Memory is what you put in it — your projects, notes, and uploads — and you control which agents, apps, and connected tools can see what. Genesis apps support login and auth so what you publish isn't wide open. For current compliance specifics, check taskade.com.
+
+## Related
+
+- [What is Taskade Genesis](genesis/what-is-taskade-genesis.md) — the capabilities pillar
+- [What an AI-native workspace is](guides/ai-workspace.md) — Memory + Intelligence + Execution
+- [What a multi-agent workspace is](guides/multi-agent-workspace.md) — the intelligence layer
+- [Glossary](glossary.md) — definitions for the terms above
+- [Comparison hub](compare/README.md) — how Taskade stacks up against other tools
+
+Ready to try it? [Build an app from a prompt with Taskade Genesis](https://www.taskade.com/ai/apps).

--- a/docs/genesis/what-is-taskade-genesis.md
+++ b/docs/genesis/what-is-taskade-genesis.md
@@ -1,0 +1,181 @@
+# What Is Taskade Genesis?
+
+[![Taskade Genesis overview — describe an app, get a running app](../../media/genesis/genesis-overview.gif)](https://www.taskade.com/ai/apps)
+
+**Taskade Genesis is an AI app builder that turns a plain-English description into a complete, hosted, working application** — database, AI agents, automations, a real user interface, login and authentication, payments, and a custom domain. You describe the outcome you want; Genesis builds the software that delivers it.
+
+It is not a mockup tool, a wireframe, or a folder of code you have to host yourself. The thing Genesis hands you is a live app at a real URL that your team or your customers can log into and use.
+
+That distinction matters. One enterprise customer who shipped a production business app solo with Genesis put it plainly: *"What I accomplished in a few weeks would have taken a team of 40+ and 18 months in the Fortune 500."* He is not an engineer. He described what he needed, and the working software showed up.
+
+This is the idea behind Genesis: **build without permission.** No ticket, no sprint, no waiting on a roadmap, no engineer required to get a real tool live.
+
+---
+
+## From a sentence to a running app
+
+The whole pipeline fits in one mental model. You write a description. Genesis generates every layer of a working application around it — and wires them together so the result runs.
+
+```mermaid
+flowchart TD
+    P["Describe your app in plain English"] --> G["Taskade Genesis"]
+    G --> DB["Database: projects and data"]
+    G --> AG["AI agents"]
+    G --> AU["Automations"]
+    G --> UI["App interface"]
+    G --> AX["Login and payments"]
+    DB --> L["Live app on your own domain"]
+    AG --> L
+    AU --> L
+    UI --> L
+    AX --> L
+```
+
+Most AI builders stop at one or two of those boxes — they generate a UI, or some code, and leave the rest to you. Genesis generates all of them at once and connects them, because they are already part of the same workspace. The agents can read the database. The automations can trigger the agents. The UI shows the data. Login and payments gate access. It arrives as one running system rather than parts you assemble.
+
+---
+
+## What Genesis builds
+
+When you describe an app, here is what actually gets created — and what each piece does for you in plain terms.
+
+| What Genesis builds | What it means for you |
+|---|---|
+| **A database** | A real place to store your projects, records, and data — not a spreadsheet you bolt on later. Your app remembers everything users put into it. |
+| **AI agents** | Specialized AI workers that live inside the app, read its data, and take action — answering questions, triaging requests, drafting replies, filling records. |
+| **Automations** | The recurring work runs itself: a form submission routes a lead, a new order emails a receipt, a status change notifies the right person. |
+| **A user interface** | Screens your team and customers actually use — dashboards, forms, tables, and views — generated to fit the app you described. |
+| **Login and authentication** | Real accounts and sign-in, so what you publish isn't wide open. You control who gets in. |
+| **Payments** | Stripe-backed checkout and paywalls built in, so the app can charge customers and log orders without third-party plumbing. |
+| **A custom domain** | Publish on your own web address (`yourbrand.com`) instead of a generic shared link. |
+| **Hosting** | The app runs at a live URL. There is nothing to deploy, no server to rent, no DevOps to learn. |
+
+The short version: other AI tools generate *code*. Genesis generates a *product*.
+
+---
+
+## How it works
+
+[![Create an app in Taskade Genesis from a plain-English prompt](../../media/genesis/create-app.gif)](https://www.taskade.com/ai/apps)
+
+The loop from idea to live app has four steps, and none of them require code.
+
+1. **Describe the outcome.** Open the [Genesis builder](https://www.taskade.com/ai/apps) and write what you want in plain English — "a CRM that tracks leads by stage and emails me when a deal closes," or "a client portal where customers log in to see project status." Be specific about the result, not the implementation.
+2. **Genesis generates the app.** It builds the projects and database, the AI agent roles, the automations, and the UI — wired together — and shows you a running app, not a spec.
+3. **Refine it in click-to-edit.** Adjust anything directly in the live interface. Move a field, reword an agent's instructions, change an automation. Changes go live immediately — there is no redeploy step and no rebuild.
+4. **Share or publish.** Invite your team, ship it to customers, add a login, turn on payments, and put it on your own domain.
+
+Because the app is live the moment it is generated, the gap between "I have an idea" and "people are using it" is measured in minutes, not quarters.
+
+---
+
+## How Genesis fits the AI-native workspace
+
+Genesis is not a separate product bolted onto Taskade. It is the **Execution** layer of one connected workspace — what Taskade calls Workspace DNA: Memory, Intelligence, and Execution running as a single feedback loop.
+
+```mermaid
+flowchart LR
+    M["Memory<br/>projects, notes, docs"] --> I["Intelligence<br/>multi-agent teams"]
+    I --> E["Execution<br/>automations and Genesis apps"]
+    E --> M
+```
+
+- **Memory** is everything your workspace knows — your projects, notes, and uploaded documents. It is the shared context.
+- **Intelligence** is your [multi-agent teams](../guides/multi-agent-workspace.md) — AI agents that reason over that memory and decide what to do.
+- **Execution** is where decisions become finished work — [automations](../guides/connect-tools-and-automate.md) and the Genesis apps they run inside.
+
+The loop closes because the apps Genesis builds feed their data back into Memory, which the agents read, which drives the next round of Execution. That is why a Genesis app ships with agents and automations already inside it: they share the same brain. Read the foundation in the [AI-native workspace guide](../guides/ai-workspace.md).
+
+---
+
+## Start from a finished app, not a blank prompt
+
+You don't have to describe everything from scratch. Taskade publishes a gallery of **app kits** — live, finished Genesis apps with their data, AI agents, and automations already wired up. Clone one in about a minute, then make it yours: rename it, add your data, add a login, and publish on your own domain.
+
+Cloning is the fastest path for common needs — a CRM, a help desk, a client portal, a storefront. You start from something that already works and adjust, rather than starting from zero. Taskade lists 150+ community kits. Browse them in [Clone-Ready App Kits](./app-kits.md), or see a worked walkthrough in [Build a CRM with AI](./build-a-crm-with-ai.md).
+
+There are three ways to start, then:
+
+- **Describe it** — write a prompt and have the app built.
+- **Clone it** — start from a finished app kit and customize.
+- **Hire an agent to run it** — bring in a pre-built role (a CFO, CMO, COO, or CEO agent) to operate the app for you.
+
+---
+
+## Who Taskade Genesis is for
+
+Genesis is for the person who knows exactly what should exist but doesn't write code:
+
+- **Operators and program managers** who keep hitting "we'd need engineering for that" and want to stop waiting.
+- **Founders** who need a real tool — a CRM, a portal, a storefront — live this week, not next quarter.
+- **Non-technical builders** on any team who can describe an outcome clearly and want the software to follow.
+
+If you have ever mapped out a tool in your head, written the requirements, and then watched it die in a backlog, Genesis is built for you. The premise is that the bottleneck was never your idea — it was access to building. That access is now a sentence.
+
+---
+
+## The honest trade-off: hosted on Taskade, no code export
+
+Here is the straight version, because it matters when you choose a tool.
+
+**Genesis apps are hosted on Taskade, and you don't get a downloadable codebase to take elsewhere.** If your requirement is "generate source code I own and deploy on my own infrastructure," Genesis is not that tool — and you should know that up front.
+
+What you get in exchange is the reason most people choose Genesis in the first place. Prompt-to-*code* tools generate files you then have to host, secure, and maintain yourself — and they hand you no AI agents, no automation engine, and no data layer. You get a starting point and a maintenance bill. Workspace and project tools can configure themselves, but they can't ship a standalone, hosted app with its own login and payments.
+
+Genesis trades code export for **everything being built-in and running**: the database, the agents, the automations, the auth, the payments, and the hosting all arrive together and stay maintained. For a non-technical builder who wants a working product rather than a repository, that is usually the trade worth making. For a team that needs to own and self-host source, it isn't — and that's a fair line to draw.
+
+See how that trade compares across categories in the [comparison hub](../compare/README.md).
+
+---
+
+## FAQ
+
+### What is Taskade Genesis?
+
+Taskade Genesis is an AI app builder that turns a plain-English description into a complete, hosted, working application — database, AI agents, automations, UI, login and auth, payments, and a custom domain. It produces a real running app, not a mockup.
+
+### How does Taskade Genesis work?
+
+You open the builder, describe the outcome in plain English, and Genesis generates the projects, agent roles, automations, and UI. You run it, refine it in click-to-edit (changes are live immediately), then share with your team or publish on a custom domain.
+
+### What does Genesis build that other AI builders don't?
+
+Genesis ships built-in intelligence — AI agents, automations, and a database — not just code files you host yourself. Prompt-to-code tools generate a UI or source you then maintain; Genesis hands you a running product with the agents and data layer already wired in.
+
+### Is the app actually hosted, or just a prototype?
+
+It's a real hosted app at a live URL with login and auth built in, and it can run on your own custom domain. It's running software your team or customers can use, not a static prototype.
+
+### Can I take payments inside an app I build?
+
+Yes. Genesis apps support Stripe-backed checkout and paywalls built in, so an app can charge a customer, log the order, and email a receipt without bolting on third-party payment tools or hiring an engineer.
+
+### Can I clone an app instead of starting from a blank prompt?
+
+Yes. You can clone a live community app kit in about a minute — data, AI agents, and automations already wired up — then rename it, add your data, add a login, and publish on your own domain. Taskade lists 150+ community kits.
+
+### Who is Taskade Genesis for?
+
+It's for operators, founders, and non-technical builders who know what they want shipped but don't write code — the "build without permission" idea: no ticket, no sprint, no engineer required to get a real tool live.
+
+### Can I build an app without code?
+
+Yes. With Genesis you describe the app in plain English and it builds a complete, hosted application — database, agents, automations, UI, login, payments, and a custom domain — with no code and no setup.
+
+### Is Taskade Genesis free to try?
+
+Yes, you can start building from a prompt for free. Higher AI usage, more agents, and more automation runs come with paid plans; verify the current details on [taskade.com](https://www.taskade.com).
+
+---
+
+## Related
+
+- [What is an AI-native workspace?](../guides/ai-workspace.md) — the Memory + Intelligence + Execution foundation Genesis runs on.
+- [What is a multi-agent workspace?](../guides/multi-agent-workspace.md) — the intelligence layer inside every Genesis app.
+- [Clone-Ready App Kits](./app-kits.md) — 150+ live apps you can clone in about a minute.
+- [Build a CRM with AI](./build-a-crm-with-ai.md) — a worked, end-to-end example.
+- [Comparison hub](../compare/README.md) — how Genesis stacks up against code builders, doc tools, and agent platforms.
+
+---
+
+**Ready to build without permission?** Describe your first app and watch it come to life at **[taskade.com/ai/apps](https://www.taskade.com/ai/apps)**.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -1,0 +1,107 @@
+# AI Workspace Glossary
+
+If you are new to AI agents, multi-agent workspaces, or building apps from a plain-English prompt, the words can get in the way of the ideas. This glossary defines the terms you will meet across Taskade's guides, comparisons, and Taskade Genesis pages in plain language, one or two sentences each. The aim is simple: read a definition, understand the thing, get back to work. Each term has its own anchor, so you can deep-link straight to it (for example, `glossary.md#ai-agent`). Terms are grouped into four themes — workspace and AI concepts, agents and memory, Genesis and apps, and automation and integrations.
+
+[![Workspace DNA — Memory, Intelligence, and Execution in one workspace](../media/automations/workspace-dna.gif)](https://www.taskade.com)
+
+---
+
+## Workspace & AI concepts
+
+### AI workspace
+A single place where your information, AI, and work live together, so asking for something and getting it done are the same motion.
+
+### AI-native workspace
+A workspace built so AI is the substrate, not a feature: agents share your data, take actions, and produce output back inside the workspace.
+
+### Multi-agent workspace
+A team of AI agents that share one memory, hand tasks to each other, and finish a job end to end, instead of one chatbot answering at a time.
+
+### Workspace DNA
+Taskade's term for the three pillars that make a workspace "alive": Memory, Intelligence, and Execution, running as one feedback loop.
+
+### Memory + Intelligence + Execution
+The shorthand for the three layers of an AI-native workspace: what it knows, what reasons over it, and what turns decisions into finished work.
+
+### Build without permission
+Taskade's positioning that a non-technical person can ship a real tool with no ticket, no sprint, and no engineer required.
+
+---
+
+## Agents & memory
+
+### AI agent
+An AI worker with its own instructions, knowledge, and tools that reads context and decides what to write or do — not just chat, but act.
+
+### Agent memory
+The shared, persistent context agents draw on — projects, notes, uploads, and past conversations — so you don't re-explain your business each session.
+
+### Workspace memory
+The collective body of projects, tasks, notes, and knowledge that forms one source of truth every agent and automation can read and write.
+
+### Delegation (agent handoff)
+When each agent owns one step and passes its result forward, so the researcher's output becomes the writer's input, defined once and run automatically.
+
+### Agentic engineering
+Building software where AI agents — not just generated code — carry the logic, acting and adapting at runtime rather than running a fixed script.
+
+---
+
+## Genesis & apps
+
+### Taskade Genesis
+An AI app builder that turns a plain-English description into a complete, hosted, working app — database, agents, automations, UI, auth, payments, domain.
+
+### Genesis app
+The output of Genesis: a real, hosted application running at a live URL, not a mockup or prototype.
+
+### App kit
+A clone-ready, live Genesis app with its data, agents, and automations already wired up; clone it in about a minute and make it yours.
+
+### Cloning
+Starting from a finished community app instead of a blank prompt, then renaming, adding your data, adding a login, and publishing on your domain.
+
+### Vibe coding
+Describing what you want in natural language and letting AI build it (term popularized by Andrej Karpathy, Feb 2025); Genesis adds built-in intelligence, not just code.
+
+### App payments
+Stripe-backed checkout and paywalls built into Genesis apps, so an app can take real money rather than relying on bolted-on tools.
+
+### Custom domain
+Publishing a Genesis app on your own web address (yourbrand.com) instead of a generic shared link.
+
+### Click-to-edit
+Refining a Genesis app or agent directly in the interface, with changes going live immediately and no redeploy step.
+
+---
+
+## Automation & integrations
+
+### Automation / workflow
+A defined process that runs the recurring work — describe the steps in plain English and the workspace runs them on its own.
+
+### Trigger
+The event that starts a flow — a form submission, a closed deal, a file landing in a folder, or a task marked done.
+
+### Schedule
+The clock-based way to run a flow — every morning, every Monday, the first of the month — rather than on an event.
+
+### Integration / connector
+A connected app (Slack, Stripe, Gmail, etc.) your agents can read from and write to; Taskade lists 100+ integrations.
+
+### MCP (Model Context Protocol)
+A shared standard for plugging tools into AI — "USB-C for AI tools" — letting tools connect to agents without a custom build per app.
+
+---
+
+## Related
+
+- [What is an AI-native workspace?](guides/ai-workspace.md) — the Memory + Intelligence + Execution foundation
+- [What is a multi-agent workspace?](guides/multi-agent-workspace.md) — AI agents and shared memory in depth
+- [Connect tools and automate](guides/connect-tools-and-automate.md) — agent memory, MCP, integrations, and flows
+- [What is Taskade Genesis?](genesis/what-is-taskade-genesis.md) — prompt-to-app, Genesis apps, click-to-edit
+- [App kits](genesis/app-kits.md) — cloning a live community app in about a minute
+- [Compare Taskade](compare/README.md) — how Taskade stacks up against other tools
+- [FAQ](faq.md) — common questions about Taskade and Genesis
+
+Ready to see these ideas running? [Build an app from a plain-English prompt with Taskade Genesis](https://www.taskade.com/ai/apps).

--- a/docs/guides/ai-workspace.md
+++ b/docs/guides/ai-workspace.md
@@ -34,6 +34,15 @@ Capable, low-cost models changed the economics of that middle step. For the firs
 
 An AI-native workspace stands on three layers. Remove any one and it collapses into something narrower — a notes app, a chatbot, or a no-code builder. Together, they're a workspace that thinks and acts.
 
+The three layers form a loop — Memory feeds Intelligence, Intelligence drives Execution, and Execution writes back to Memory:
+
+```mermaid
+flowchart LR
+    M["Memory<br/>projects, notes, docs"] --> I["Intelligence<br/>multi-agent teams"]
+    I --> E["Execution<br/>automations and Taskade Genesis apps"]
+    E --> M
+```
+
 ### Layer 1 — Memory: projects and notes as living context
 
 Memory is everything your workspace knows: your projects, tasks, notes, mind maps, uploaded documents, and the way they connect. In a traditional tool this is *storage* — inert files you open and read. In an AI-native workspace it's **context the AI can use**.
@@ -55,7 +64,7 @@ One agent drafts. Another fact-checks against your uploaded sources. A third tur
 Knowing and thinking are worthless if nothing happens. Execution is the layer that turns intent into action.
 
 - **Automations / workflows** handle the recurring work: when a form comes in, route it; every Monday, compile the report; when a task is marked done, notify the channel. You describe the trigger and the steps in plain English; the workspace runs them on its own.
-- **Genesis** goes further. Describe an app in plain English and Genesis builds a complete, hosted, working application — database, AI agents, automations, UI, login and auth, payments, and a custom domain. Not a mockup. A real app your team or customers can use today. See it at the [Genesis app builder](https://www.taskade.com/ai/apps).
+- **Taskade Genesis** goes further. Describe an app in plain English and Genesis builds a complete, hosted, working application — database, AI agents, automations, UI, login and auth, payments, and a custom domain. Not a mockup. A real app your team or customers can use today. See it at the [Genesis app builder](https://www.taskade.com/ai/apps).
 
 This is the layer that separates an AI-native workspace from a smarter notebook. The output isn't just text — it's running software and live processes.
 

--- a/docs/guides/multi-agent-workspace.md
+++ b/docs/guides/multi-agent-workspace.md
@@ -23,6 +23,20 @@ The key word is **workspace**. The agents don't live in a chat window that forge
 
 Put simply: a chatbot is a conversation, a single assistant is a helper, and a multi-agent workspace is an operation. The first two wait for your next message. The third keeps working — picking up where the last agent left off, against context that's still there tomorrow.
 
+One prompt fans out to a team of specialized agents, who all read and write the same workspace memory, and the finished work comes back to you:
+
+```mermaid
+flowchart LR
+    U["You: one prompt"] --> O["Lead agent"]
+    O --> A["Researcher"]
+    O --> B["Writer"]
+    O --> C["Reviewer"]
+    A --> MEM[("Shared workspace memory")]
+    B --> MEM
+    C --> MEM
+    MEM --> R["Finished work"]
+```
+
 ---
 
 ## Why a team beats one assistant
@@ -68,7 +82,7 @@ Most tools give you one of these. The combination is what makes a workspace.
 
 - **Memory** — projects, notes, and knowledge the agents draw on. Persistent, shared, searchable.
 - **Intelligence** — the agent team that reasons over that memory and decides what to do.
-- **Execution** — [automations and workflows](../guides/ai-workspace.md) plus [Genesis](https://www.taskade.com/ai/apps) apps that turn decisions into finished work — tasks created, records filled, customers emailed, an app shipped.
+- **Execution** — [automations and workflows](../guides/ai-workspace.md) plus [Taskade Genesis](https://www.taskade.com/ai/apps) apps that turn decisions into finished work — tasks created, records filled, customers emailed, an app shipped.
 
 ```
                  ┌──────────────────────────────────────┐


### PR DESCRIPTION
## What this PR does

Additive **SEO + AEO (answer-engine optimization) + discoverability** expansion of the docs hub, plus GitHub-native **Mermaid diagrams** and standard **community-health** files. Strictly additive — no existing content removed (the only "deletions" are in-place branding rewordings to lead with "Taskade Genesis"). **+1,419 / −2.**

Grounded in fresh multi-agent research: a top-10 competitor refresh, an answer-engine question/intent study, and per-competitor fact-checking — all synthesized into a content brief.

## Why

- **Communicate the full capability of Taskade Genesis** with a definitive pillar page.
- **Win organically** for category + "alternative" + question intent across both classic SEO and AI answer engines (ChatGPT / Perplexity / Google AI Overviews), which favor extractable tables, definitions, and Q&A.
- **Improve discoverability** by routing the org's existing audiences (the 146★ `mcp` and 57★ `awesome-vibe-coding` repos) into this one.

## New content (SEO/AEO)

| Page | Targets | Notes |
|---|---|---|
| `docs/genesis/what-is-taskade-genesis.md` | "what is Taskade Genesis", "AI app builder from a prompt" | Capabilities pillar — **2 Mermaid diagrams**, capability table, GIFs, AEO FAQ, honest no-code-export caveat |
| `docs/faq.md` | "Taskade Genesis FAQ", "is it free", "no code", "hosted apps" | 28 question/answer pairs, AEO-formatted |
| `docs/glossary.md` | "AI workspace glossary", "what is a multi-agent workspace / agent memory / MCP" | 24 deep-linkable definitions |
| `docs/compare/README.md` | "Taskade alternatives", "AI workspace comparison" | Comparison hub indexing all 8 comparisons |
| `docs/compare/taskade-vs-asana.md` | "Taskade vs Asana", "Asana alternative with AI" | Honest; Asana AI shown as **metered AI Studio credits** |
| `docs/compare/taskade-vs-coda.md` | "Taskade vs Coda", "Coda alternative" | Honest; Coda/Superhuman status **hedged** as reported |
| `docs/compare/taskade-vs-ai-agent-tools.md` | "best AI agent platform", "Taskade vs Lindy" | Lindy / Gumloop / **Zapier Agents**, fairly credited |

## Visuals (Mermaid + media)

- **README:** a GitHub-rendered Mermaid "prompt → app" pipeline diagram (alongside the existing ASCII loop).
- **Mermaid added** to the multi-agent and AI-workspace pillars (Memory → Intelligence → Execution loop; multi-agent flow).
- Reused newsletter GIFs across the new pages.

## Discoverability + community health

- **README:** top-of-readme star CTA, a table of contents, a **Taskade Ecosystem** section cross-linking `mcp` / `awesome-vibe-coding` / sample-app with star badges, and a **star-history chart**.
- New pages wired into **Learn & Compare** and the **docs hub index**.
- `LICENSE`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md` (with a **community app-kit submission funnel**), issue forms (bug / feature / **submit-app-kit**) + `config.yml` + PR template — closes the community-health gaps (was 37%).

## Quality gates (all passed)

- ✅ All internal `.md` links and image paths resolve; one H1 per page
- ✅ **All Mermaid fences balanced/valid** (verified)
- ✅ Honest comparisons; **no fabricated stats** (only Taskade's own published figures; competitor figures cited)
- ✅ "Taskade Genesis" on first mention; issue-form YAML validated

## Note for reviewers

`LICENSE` is a conservative default (docs referenceable with attribution; brand assets/media reserved © Taskade) — easy for legal to swap to a formal SPDX license. Pure content/docs PR; no application code.
