### PR TITLE
docs(readme): add Taskade Docs + Integration Kit to ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,8 +486,9 @@ npx @taskade/mcp
 | **[REST API v2](https://developers.taskade.com)** | Full workspace, project, and agent management |
 | **[MCP Server v2](https://github.com/taskade/mcp)** | Model Context Protocol for ChatGPT, Claude, Cursor, VS Code |
 | **[Agent API](https://developers.taskade.com)** | Deploy and manage agents programmatically |
-| **Webhooks** | Receive real-time events from your workspace |
-| **OAuth 2.0** | Secure third-party authentication |
+| **[Integration Kit](https://github.com/taskade/integrations)** | Open-source Zapier/n8n actions & triggers built on the public API |
+| **[Webhooks](https://docs.taskade.com/apis-and-developer/webhooks)** | Receive real-time events from your workspace |
+| **[OAuth 2.0](https://docs.taskade.com/apis-and-developer/authentication)** | Secure third-party authentication |
 | **BYOK** | Bring your own AI model keys (Business plan) |
 | **Custom Agent Tools** | Extend agents with custom API integrations |
 | **Embeddable Apps** | Embed Taskade apps and agents anywhere |
@@ -888,10 +889,12 @@ Taskade is more than this repo — explore the rest of the ecosystem (and star w
 | [**Taskade MCP**](https://github.com/taskade/mcp) | Official Model Context Protocol server — connect Taskade to Claude, Cursor, and any MCP client. | [![mcp stars](https://img.shields.io/github/stars/taskade/mcp?style=social)](https://github.com/taskade/mcp) |
 | [**Awesome Vibe Coding**](https://github.com/taskade/awesome-vibe-coding) | A curated guide to building software with AI — the vibe-coding movement. | [![awesome-vibe-coding stars](https://img.shields.io/github/stars/taskade/awesome-vibe-coding?style=social)](https://github.com/taskade/awesome-vibe-coding) |
 | [**Genesis Sample App**](https://github.com/taskade/taskade-sample-app) | A Workspace DNA template for building AI-powered Taskade Genesis apps. | [![sample-app stars](https://img.shields.io/github/stars/taskade/taskade-sample-app?style=social)](https://github.com/taskade/taskade-sample-app) |
+| [**Taskade Docs**](https://github.com/taskade/docs) | Source for [docs.taskade.com](https://docs.taskade.com) — REST & Action API reference, Genesis app building, AI agents, and automations. PRs welcome. | [![docs stars](https://img.shields.io/github/stars/taskade/docs?style=social)](https://github.com/taskade/docs) |
+| [**Integration Kit**](https://github.com/taskade/integrations) | Public source-of-truth for Taskade actions & triggers across Zapier and n8n — built on the public API. | [![integrations stars](https://img.shields.io/github/stars/taskade/integrations?style=social)](https://github.com/taskade/integrations) |
 
 ### Star history
 
-[![Star History Chart](https://api.star-history.com/svg?repos=taskade/taskade,taskade/mcp,taskade/awesome-vibe-coding&type=Date)](https://star-history.com/#taskade/taskade&taskade/mcp&taskade/awesome-vibe-coding&Date)
+[![Star History Chart](https://api.star-history.com/svg?repos=taskade/taskade,taskade/mcp,taskade/awesome-vibe-coding,taskade/docs&type=Date)](https://star-history.com/#taskade/taskade&taskade/mcp&taskade/awesome-vibe-coding&taskade/docs&Date)
 
 ---
 


### PR DESCRIPTION
## What

README-only change adding the two missing public repos to the org's self-referencing link graph:

- **Taskade Ecosystem table** — two new rows: [**Taskade Docs**](https://github.com/taskade/docs) (source for docs.taskade.com) and [**Integration Kit**](https://github.com/taskade/integrations) (Zapier/n8n actions & triggers), each with a matching `style=social` stars shield.
- **Developer Tools table** — one new row for the Integration Kit.
- **Webhooks & OAuth 2.0 rows** — were plain text; now linked to their live docs pages ([webhooks](https://docs.taskade.com/apis-and-developer/webhooks), [authentication](https://docs.taskade.com/apis-and-developer/authentication)), both verified to return HTTP 200.
- **Star History chart** — `taskade/docs` added to the `repos=` param in both the image src and the link href.

## Why

Taskade's public repos currently don't cross-link, so developers arriving from the MCP registry, npm (`@taskade/mcp-server`), docs.taskade.com, or the awesome-lists hit a dead end at whichever repo they land on. This closes the org link graph from the flagship repo: ecosystem table → docs + integrations, and the developer table → the open-source integration source-of-truth.

Taskade Genesis is the AI app builder — one prompt generates a working app backed by your workspace: projects become the database, AI agents the team, automations the execution layer, with 100+ integrations and MCP support. Docs: https://docs.taskade.com

## Zero-regression verification

Checks actually run before pushing:

- [x] `curl -sL -o /dev/null -w "%{http_code}"` → **200** for every new/changed URL: `github.com/taskade/docs`, `github.com/taskade/integrations`, `docs.taskade.com`, `docs.taskade.com/apis-and-developer/webhooks`, `docs.taskade.com/apis-and-developer/authentication`, both shields.io star badges, and both new Star History URLs (img src + href)
- [x] Negative control: `docs.taskade.com/definitely-not-a-real-page-xyz123` → **404**, confirming the 200s above are real pages, not a catch-all
- [x] Content check: the authentication page contains "OAuth 2.0" sections; the webhooks page title is "Webhooks | Taskade Docs"
- [x] Markdown table pipe counts consistent per row: Developer Tools table 3 pipes/row (2 cols), Ecosystem table 4 pipes/row (3 cols), including all new rows
- [x] `git diff` contains ONLY the intended lines: 6 insertions, 3 deletions, all in the two tables + Star History line; no other section touched

cc @deanzaka @lxcid
